### PR TITLE
Use `java-library` plugin instead of `java` in core module

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -23,11 +23,11 @@
  */
 
 plugins {
-    java
+    id("java-library")
 }
 
 dependencies {
+    api("com.linecorp.armeria:armeria:1.1.0")
     implementation("com.google.guava:guava:29.0-jre")
-    implementation("com.linecorp.armeria:armeria:1.1.0")
     implementation("org.slf4j:slf4j-api:1.7.30")
 }

--- a/examples/pokeapi/pokeapi-gateway/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-gateway/build.gradle.kts
@@ -31,7 +31,6 @@ plugins {
 dependencies {
     implementation(project(":core"))
 
-    implementation("com.linecorp.armeria:armeria:1.1.0")
     implementation("org.slf4j:slf4j-api:1.7.30")
 
     runtimeOnly("ch.qos.logback:logback-classic:1.2.3")


### PR DESCRIPTION
Use `java-library` plugin instead of `java` in core module because `java` plugin doesn't support `api` dependency.