### PR TITLE
Add name to checkout step in build master workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,7 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
### Motivation

The `actions/checkout@v2` step in `Build master` workflow doesn't have any name.

### Description

Add name `Checkout repository` as same as `Build pull request` workflow.