### PR TITLE
Implement initializing and comparing configs with unit tests

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -31,9 +31,21 @@ dependencies {
     implementation("com.google.guava:guava:29.0-jre")
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("org.slf4j:slf4j-api:1.7.30")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
+    testImplementation("org.assertj:assertj-core:3.17.2")
+    testImplementation("org.mockito:mockito-core:3.5.13")
+    testImplementation("org.awaitility:awaitility:4.0.3")
+    testImplementation("com.linecorp.armeria:armeria-junit5:1.1.0")
+
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
 }
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/core/src/main/java/dev/gihwan/tollgate/core/endpoint/EndpointConfig.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/endpoint/EndpointConfig.java
@@ -24,15 +24,24 @@
 
 package dev.gihwan.tollgate.core.endpoint;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 import com.linecorp.armeria.common.HttpMethod;
 
 import dev.gihwan.tollgate.core.upstream.UpstreamConfig;
 
 public final class EndpointConfig {
+
+    public static EndpointConfig of(HttpMethod method, String path, UpstreamConfig upstream) {
+        return new EndpointConfig(method, path, upstream);
+    }
 
     private final HttpMethod method;
     private final String path;
@@ -42,9 +51,9 @@ public final class EndpointConfig {
     private EndpointConfig(@JsonProperty("method") HttpMethod method,
                            @JsonProperty("path") String path,
                            @JsonProperty("upstream") UpstreamConfig upstream) {
-        this.method = method;
-        this.path = path;
-        this.upstream = upstream;
+        this.method = requireNonNull(method, "method");
+        this.path = requireNonNull(path, "path");
+        this.upstream = requireNonNull(upstream, "upstream");
     }
 
     public HttpMethod method() {
@@ -57,6 +66,27 @@ public final class EndpointConfig {
 
     public UpstreamConfig upstream() {
         return upstream;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof EndpointConfig)) {
+            return false;
+        }
+
+        final EndpointConfig that = (EndpointConfig) o;
+        return Objects.equal(method, that.method) &&
+               Objects.equal(path, that.path) &&
+               Objects.equal(upstream, that.upstream);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(method, path, upstream);
     }
 
     @Override

--- a/core/src/main/java/dev/gihwan/tollgate/core/service/Authority.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/service/Authority.java
@@ -24,13 +24,23 @@
 
 package dev.gihwan.tollgate.core.service;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 import com.linecorp.armeria.client.Endpoint;
 
 public final class Authority {
+
+    public static Authority of(String host, int port) {
+        return new Authority(host, port);
+    }
 
     private final String host;
     private final int port;
@@ -38,7 +48,9 @@ public final class Authority {
     @JsonCreator
     private Authority(@JsonProperty("host") String host,
                       @JsonProperty("port") int port) {
-        this.host = host;
+        this.host = requireNonNull(host, "host");
+        checkArgument(port >= 0, "port: %s (expected: >= 0)", port);
+        checkArgument(port <= 65535, "port: %s (expected: <= 65535)", port);
         this.port = port;
     }
 
@@ -52,6 +64,26 @@ public final class Authority {
 
     public Endpoint toArmeriaEndpoint() {
         return Endpoint.of(host, port);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof Authority)) {
+            return false;
+        }
+
+        final Authority that = (Authority) o;
+        return Objects.equal(host, that.host) &&
+               port == that.port;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(host, port);
     }
 
     @Override

--- a/core/src/main/java/dev/gihwan/tollgate/core/upstream/UpstreamConfig.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/upstream/UpstreamConfig.java
@@ -24,13 +24,22 @@
 
 package dev.gihwan.tollgate.core.upstream;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 import dev.gihwan.tollgate.core.service.ServiceConfig;
 
 public final class UpstreamConfig {
+
+    public static UpstreamConfig of(ServiceConfig service, UpstreamEndpointConfig endpoint) {
+        return new UpstreamConfig(service, endpoint);
+    }
 
     private final ServiceConfig service;
     private final UpstreamEndpointConfig endpoint;
@@ -38,8 +47,8 @@ public final class UpstreamConfig {
     @JsonCreator
     private UpstreamConfig(@JsonProperty("service") ServiceConfig service,
                            @JsonProperty("endpoint") UpstreamEndpointConfig endpoint) {
-        this.service = service;
-        this.endpoint = endpoint;
+        this.service = requireNonNull(service, "service");
+        this.endpoint = requireNonNull(endpoint, "endpoint");
     }
 
     public ServiceConfig service() {
@@ -48,6 +57,27 @@ public final class UpstreamConfig {
 
     public UpstreamEndpointConfig endpoint() {
         return endpoint;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof UpstreamConfig)) {
+            return false;
+        }
+
+        final UpstreamConfig that = (UpstreamConfig) o;
+
+        return Objects.equal(service, that.service) &&
+               Objects.equal(endpoint, that.endpoint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(service, endpoint);
     }
 
     @Override

--- a/core/src/main/java/dev/gihwan/tollgate/core/upstream/UpstreamConfig.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/upstream/UpstreamConfig.java
@@ -70,7 +70,6 @@ public final class UpstreamConfig {
         }
 
         final UpstreamConfig that = (UpstreamConfig) o;
-
         return Objects.equal(service, that.service) &&
                Objects.equal(endpoint, that.endpoint);
     }

--- a/core/src/main/java/dev/gihwan/tollgate/core/upstream/UpstreamEndpointConfig.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/upstream/UpstreamEndpointConfig.java
@@ -24,13 +24,22 @@
 
 package dev.gihwan.tollgate.core.upstream;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 import com.linecorp.armeria.common.HttpMethod;
 
 public final class UpstreamEndpointConfig {
+
+    public static UpstreamEndpointConfig of(HttpMethod method, String path) {
+        return new UpstreamEndpointConfig(method, path);
+    }
 
     private final HttpMethod method;
     private final String path;
@@ -38,8 +47,8 @@ public final class UpstreamEndpointConfig {
     @JsonCreator
     private UpstreamEndpointConfig(@JsonProperty("method") HttpMethod method,
                                    @JsonProperty("path") String path) {
-        this.method = method;
-        this.path = path;
+        this.method = requireNonNull(method, "method");
+        this.path = requireNonNull(path, "path");
     }
 
     public HttpMethod method() {
@@ -48,6 +57,26 @@ public final class UpstreamEndpointConfig {
 
     public String path() {
         return path;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof UpstreamEndpointConfig)) {
+            return false;
+        }
+
+        final UpstreamEndpointConfig that = (UpstreamEndpointConfig) o;
+        return Objects.equal(method, that.method) &&
+               Objects.equal(path, that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(method, path);
     }
 
     @Override

--- a/core/src/test/java/dev/gihwan/tollgate/core/endpoint/EndpointConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/endpoint/EndpointConfigTest.java
@@ -1,0 +1,88 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.core.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpMethod;
+
+import dev.gihwan.tollgate.core.service.ServiceConfig;
+import dev.gihwan.tollgate.core.upstream.UpstreamConfig;
+import dev.gihwan.tollgate.core.upstream.UpstreamEndpointConfig;
+
+@SuppressWarnings("ConstantConditions")
+class EndpointConfigTest {
+
+    @Test
+    void of() {
+        assertThatThrownBy(() -> EndpointConfig.of(null, null, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> EndpointConfig.of(null, "/api", newUpstreamConfig()))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> EndpointConfig.of(HttpMethod.GET, null, newUpstreamConfig()))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> EndpointConfig.of(HttpMethod.GET, "/api", null))
+                .isInstanceOf(NullPointerException.class);
+
+        final EndpointConfig config = EndpointConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
+        assertThat(config.method()).isEqualTo(HttpMethod.GET);
+        assertThat(config.path()).isEqualTo("/api");
+        assertThat(config.upstream()).isEqualTo(newUpstreamConfig());
+    }
+
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
+    @Test
+    void equals() {
+        final EndpointConfig config = EndpointConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
+
+        final EndpointConfig same = EndpointConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
+        final EndpointConfig differentMethod = EndpointConfig.of(HttpMethod.POST, "/api", newUpstreamConfig());
+        final EndpointConfig differentPath = EndpointConfig.of(HttpMethod.GET, "/api/v1", newUpstreamConfig());
+        final EndpointConfig differentUpstream =
+                EndpointConfig.of(HttpMethod.GET, "/api", newUpstreamConfig("http://example.org"));
+
+        assertThat(config.equals(same)).isTrue();
+        assertThat(config.equals(differentMethod)).isFalse();
+        assertThat(config.equals(differentPath)).isFalse();
+        assertThat(config.equals(differentUpstream)).isFalse();
+
+        assertThat(config.equals(null)).isFalse();
+        assertThat(config.equals(new Dummy())).isFalse();
+    }
+
+    private static UpstreamConfig newUpstreamConfig() {
+        return newUpstreamConfig("http://example.com");
+    }
+
+    private static UpstreamConfig newUpstreamConfig(String uri) {
+        return UpstreamConfig.of(ServiceConfig.of(uri),
+                                 UpstreamEndpointConfig.of(HttpMethod.GET, "/api"));
+    }
+
+    private static class Dummy {}
+}

--- a/core/src/test/java/dev/gihwan/tollgate/core/service/AuthorityTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/service/AuthorityTest.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.core.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("ConstantConditions")
+class AuthorityTest {
+
+    @Test
+    void of() {
+        assertThatThrownBy(() -> Authority.of(null, 0))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Authority.of("127.0.0.1", -1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Authority.of("127.0.0.1", 65536))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final Authority authority = Authority.of("127.0.0.1", 8080);
+        assertThat(authority.host()).isEqualTo("127.0.0.1");
+        assertThat(authority.port()).isEqualTo(8080);
+    }
+
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
+    @Test
+    void equals() {
+        final Authority authority = Authority.of("127.0.0.1", 8080);
+
+        final Authority same = Authority.of("127.0.0.1", 8080);
+        final Authority differentHost = Authority.of("127.0.0.2", 8080);
+        final Authority differentPort = Authority.of("127.0.0.1", 8081);
+
+        assertThat(authority.equals(same)).isTrue();
+        assertThat(authority.equals(differentHost)).isFalse();
+        assertThat(authority.equals(differentPort)).isFalse();
+
+        assertThat(authority.equals(null)).isFalse();
+        assertThat(authority.equals(new Dummy())).isFalse();
+    }
+
+    private static class Dummy {}
+}

--- a/core/src/test/java/dev/gihwan/tollgate/core/service/ServiceConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/service/ServiceConfigTest.java
@@ -105,7 +105,6 @@ class ServiceConfigTest {
 
         assertThat(config.equals(null)).isFalse();
         assertThat(config.equals(new Dummy())).isFalse();
-
     }
 
     private static class Dummy {}

--- a/core/src/test/java/dev/gihwan/tollgate/core/service/ServiceConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/service/ServiceConfigTest.java
@@ -1,0 +1,112 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.core.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.Scheme;
+
+@SuppressWarnings("ConstantConditions")
+class ServiceConfigTest {
+
+    @Test
+    void ofUri() {
+        assertThatThrownBy(() -> ServiceConfig.of(null))
+                .isInstanceOf(NullPointerException.class);
+
+        final ServiceConfig config = ServiceConfig.of("http://example.com");
+        assertThat(config.uri()).isEqualTo("http://example.com");
+        assertThat(config.scheme()).isNull();
+        assertThat(config.authorities()).isNull();
+    }
+
+    @Test
+    void ofSchemeAndAuthorities() {
+        assertThatThrownBy(() -> ServiceConfig.of(null, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> ServiceConfig.of("http", null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> ServiceConfig.of("http", Collections.emptyList()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ServiceConfig.of(null, List.of(Authority.of("127.0.0.1", 8080))))
+                .isInstanceOf(NullPointerException.class);
+
+        final ServiceConfig config = ServiceConfig.of("http",
+                                                      List.of(Authority.of("127.0.0.1", 8080),
+                                                              Authority.of("127.0.0.1", 8081)));
+        assertThat(config.uri()).isNull();
+        assertThat(config.scheme()).isEqualTo(Scheme.parse("http"));
+        assertThat(config.authorities())
+                .contains(Authority.of("127.0.0.1", 8080), Authority.of("127.0.0.1", 8081));
+    }
+
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
+    @Test
+    void equalsWithUri() {
+        final ServiceConfig config = ServiceConfig.of("http://example.com");
+
+        final ServiceConfig same = ServiceConfig.of("http://example.com");
+        final ServiceConfig differentUri = ServiceConfig.of("http://example.org");
+        final ServiceConfig differentSchemeAndAuthorities =
+                ServiceConfig.of("http", List.of(Authority.of("127.0.0.1", 8080)));
+
+        assertThat(config.equals(same)).isTrue();
+        assertThat(config.equals(differentUri)).isFalse();
+        assertThat(config.equals(differentSchemeAndAuthorities)).isFalse();
+
+        assertThat(config.equals(null)).isFalse();
+        assertThat(config.equals(new Dummy())).isFalse();
+    }
+
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
+    @Test
+    void equalsWithSchemeAndAuthorities() {
+        final ServiceConfig config = ServiceConfig.of("http", List.of(Authority.of("127.0.0.1", 8080)));
+
+        final ServiceConfig same = ServiceConfig.of("http", List.of(Authority.of("127.0.0.1", 8080)));
+        final ServiceConfig differentScheme =
+                ServiceConfig.of("https", List.of(Authority.of("127.0.0.1", 8080)));
+        final ServiceConfig differentAuthorities =
+                ServiceConfig.of("http", List.of(Authority.of("127.0.0.1", 8081)));
+        final ServiceConfig differentUri = ServiceConfig.of("http://example.com");
+
+        assertThat(config.equals(same)).isTrue();
+        assertThat(config.equals(differentScheme)).isFalse();
+        assertThat(config.equals(differentAuthorities)).isFalse();
+        assertThat(config.equals(differentUri)).isFalse();
+
+        assertThat(config.equals(null)).isFalse();
+        assertThat(config.equals(new Dummy())).isFalse();
+
+    }
+
+    private static class Dummy {}
+}

--- a/core/src/test/java/dev/gihwan/tollgate/core/upstream/UpstreamConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/upstream/UpstreamConfigTest.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.core.upstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpMethod;
+
+import dev.gihwan.tollgate.core.service.ServiceConfig;
+
+@SuppressWarnings("ConstantConditions")
+class UpstreamConfigTest {
+
+    @Test
+    void of() {
+        assertThatThrownBy(() -> UpstreamConfig.of(null, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> UpstreamConfig.of(ServiceConfig.of("http://example.com"), null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> UpstreamConfig.of(null, UpstreamEndpointConfig.of(HttpMethod.GET, "/api")))
+                .isInstanceOf(NullPointerException.class);
+
+        final UpstreamConfig config = UpstreamConfig.of(ServiceConfig.of("http://example.com"),
+                                                        UpstreamEndpointConfig.of(HttpMethod.GET, "/api"));
+        assertThat(config.service()).isEqualTo(ServiceConfig.of("http://example.com"));
+        assertThat(config.endpoint()).isEqualTo(UpstreamEndpointConfig.of(HttpMethod.GET, "/api"));
+    }
+
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
+    @Test
+    void equals() {
+        final UpstreamConfig config = UpstreamConfig.of(ServiceConfig.of("http://example.com"),
+                                                        UpstreamEndpointConfig.of(HttpMethod.GET, "/api"));
+
+        final UpstreamConfig same = UpstreamConfig.of(ServiceConfig.of("http://example.com"),
+                                                      UpstreamEndpointConfig.of(HttpMethod.GET, "/api"));
+        final UpstreamConfig differentService =
+                UpstreamConfig.of(ServiceConfig.of("http://example.org"),
+                                  UpstreamEndpointConfig.of(HttpMethod.GET, "/api"));
+        final UpstreamConfig differentEndpoint =
+                UpstreamConfig.of(ServiceConfig.of("http://example.com"),
+                                  UpstreamEndpointConfig.of(HttpMethod.POST, "/api"));
+
+        assertThat(config.equals(same)).isTrue();
+        assertThat(config.equals(differentService)).isFalse();
+        assertThat(config.equals(differentEndpoint)).isFalse();
+
+        assertThat(config.equals(null)).isFalse();
+        assertThat(config.equals(new Dummy())).isFalse();
+    }
+
+    private static class Dummy {}
+}

--- a/core/src/test/java/dev/gihwan/tollgate/core/upstream/UpstreamEndpointConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/upstream/UpstreamEndpointConfigTest.java
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.core.upstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpMethod;
+
+@SuppressWarnings("ConstantConditions")
+class UpstreamEndpointConfigTest {
+
+    @Test
+    void of() {
+        assertThatThrownBy(() -> UpstreamEndpointConfig.of(null, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> UpstreamEndpointConfig.of(HttpMethod.GET, null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> UpstreamEndpointConfig.of(null, "/api"))
+                .isInstanceOf(NullPointerException.class);
+
+        final UpstreamEndpointConfig config = UpstreamEndpointConfig.of(HttpMethod.GET, "/api");
+        assertThat(config.method()).isEqualTo(HttpMethod.GET);
+        assertThat(config.path()).isEqualTo("/api");
+    }
+
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
+    @Test
+    void equals() {
+        final UpstreamEndpointConfig config = UpstreamEndpointConfig.of(HttpMethod.GET, "/api");
+
+        final UpstreamEndpointConfig same = UpstreamEndpointConfig.of(HttpMethod.GET, "/api");
+        final UpstreamEndpointConfig differentMethod = UpstreamEndpointConfig.of(HttpMethod.POST, "/api");
+        final UpstreamEndpointConfig differentPath = UpstreamEndpointConfig.of(HttpMethod.GET, "/api/v1");
+
+        assertThat(config.equals(same)).isTrue();
+        assertThat(config.equals(differentMethod)).isFalse();
+        assertThat(config.equals(differentPath)).isFalse();
+
+        assertThat(config.equals(null)).isFalse();
+        assertThat(config.equals(new Dummy())).isFalse();
+    }
+
+    private static class Dummy {}
+}

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -34,9 +34,21 @@ dependencies {
     implementation("org.slf4j:slf4j-api:1.7.30")
 
     runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
+    testImplementation("org.assertj:assertj-core:3.17.2")
+    testImplementation("org.mockito:mockito-core:3.5.13")
+    testImplementation("org.awaitility:awaitility:4.0.3")
+    testImplementation("com.linecorp.armeria:armeria-junit5:1.1.0")
+
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
 }
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.test {
+    useJUnitPlatform()
 }


### PR DESCRIPTION
### Motivation

#41

### Description

 - Add dependencies for testing
   - `junit-jupiter`
   - `assertj`
   - `mockito`
   - `awaitility`
   - `armeria-junit5`
 - Implement initializing and comparing configs with unit tests
   - `EndpointConfig`
   - `Authority`
   - `ServiceConfig`
   - `UpstreamConfig`
   - `UpstreamEndpointConfig`