### PR TITLE
Make default classes package protected

### DIFF
--- a/core/src/main/java/dev/gihwan/tollgate/core/endpoint/DefaultEndpoint.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/endpoint/DefaultEndpoint.java
@@ -27,7 +27,7 @@ package dev.gihwan.tollgate.core.endpoint;
 import dev.gihwan.tollgate.core.upstream.Upstream;
 import dev.gihwan.tollgate.core.upstream.UpstreamFactory;
 
-public final class DefaultEndpoint implements Endpoint {
+final class DefaultEndpoint implements Endpoint {
 
     private final EndpointConfig config;
     private final Upstream upstream;

--- a/core/src/main/java/dev/gihwan/tollgate/core/service/DefaultService.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/service/DefaultService.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 
-public final class DefaultService implements Service {
+final class DefaultService implements Service {
 
     private final ServiceConfig config;
     private final WebClient client;

--- a/core/src/main/java/dev/gihwan/tollgate/core/upstream/DefaultUpstream.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/upstream/DefaultUpstream.java
@@ -47,7 +47,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import dev.gihwan.tollgate.core.service.Service;
 import dev.gihwan.tollgate.core.service.ServiceFactory;
 
-public final class DefaultUpstream implements Upstream {
+final class DefaultUpstream implements Upstream {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultUpstream.class);
 


### PR DESCRIPTION
### Motivation

Default classes can be accessed outside package.

### Description

Make default classes (`DefaultEndpoint`, `DefaultService` and `DefaultUpstream`) package protected.
