### PR TITLE
Change `tollgate.endpoints` config to object

### DIFF
--- a/examples/pokeapi/pokeapi-gateway/endpoints/berry.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/berry.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getBerry {
       method = "GET"
       path = "/api/v2/berry/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     berry {
       scheme = "http"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/contest.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/contest.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getContestType {
       method = "GET"
       path = "/api/v2/contest-type/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     contest {
       uri = "http://contest:8080"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/encounter.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/encounter.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getEncounterMethod {
       method = "GET"
       path = "/api/v2/encounter-method/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     encounter {
       uri = "http://encounter:8080"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/evolution.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/evolution.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getEvolutionChain {
       method = "GET"
       path = "/api/v2/evolution-chain/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     evolution {
       uri = "http://evolution:8080"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/game.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/game.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getGeneration {
       method = "GET"
       path = "/api/v2/generation/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     game {
       uri = "http://game:8080"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/item.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/item.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getItem {
       method = "GET"
       path = "/api/v2/item/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     item {
       uri = "http://item:8080"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/location.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/location.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getLocation {
       method = "GET"
       path = "/api/v2/location/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     location {
       uri = "http://location:8080"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/machine.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/machine.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getMachine {
       method = "GET"
       path = "/api/v2/machine/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     machine {
       uri = "http://machine:8080"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/move.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/move.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getMove {
       method = "GET"
       path = "/api/v2/move/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     move {
       uri = "http://move:8080"

--- a/examples/pokeapi/pokeapi-gateway/endpoints/pokemon.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/pokemon.conf
@@ -1,6 +1,6 @@
 tollgate {
-  endpoints = ${tollgate.endpoints} [
-    {
+  endpoints {
+    getAbility {
       method = "GET"
       path = "/api/v2/ability/{idOrName}"
       upstream {
@@ -11,7 +11,7 @@ tollgate {
         }
       }
     }
-  ]
+  }
   services {
     pokemon {
       uri = "http://pokemon:8080"

--- a/standalone/src/main/java/dev/gihwan/tollgate/standalone/Main.java
+++ b/standalone/src/main/java/dev/gihwan/tollgate/standalone/Main.java
@@ -27,6 +27,7 @@ package dev.gihwan.tollgate.standalone;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -68,10 +69,11 @@ public final class Main {
                                                 .port(config.getInt("tollgate.port"))
                                                 .healthCheckPath(config.getString("tollgate.healthCheckPath"));
 
-        config.getObjectList("tollgate.endpoints")
-              .stream()
-              .map(ConfigObject::toConfig)
-              .forEach(endpointConfig -> buildEndpoint(builder, endpointConfig));
+        final Set<String> endpointNames = config.getObject("tollgate.endpoints").keySet();
+        endpointNames.stream()
+                     .map(name -> config.getObject("tollgate.endpoints." + name))
+                     .map(ConfigObject::toConfig)
+                     .forEach(endpointConfig -> buildEndpoint(builder, endpointConfig));
 
         tollgate = builder.build();
         tollgate.start();

--- a/standalone/src/main/resources/reference.conf
+++ b/standalone/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 tollgate {
-    port = 8080
-    healthCheckPath = "/health"
-    endpoints = []
+  port = 8080
+  healthCheckPath = "/health"
+  endpoints {}
 }


### PR DESCRIPTION
### Motivation

To configure `endpoints` using object instead of list.
It will make users give each endpoints name more clear.

### Description

Users will configure endpoints as key-value object.
