### PR TITLE
Add other pokeapi-berry endpoints to pokeapi-gateway

### DIFF
--- a/examples/pokeapi/pokeapi-berry/src/main/resources/berry-firmness.json
+++ b/examples/pokeapi/pokeapi-berry/src/main/resources/berry-firmness.json
@@ -1,0 +1,19 @@
+{
+  "id": 1,
+  "name": "very-soft",
+  "berries": [
+    {
+      "name": "pecha",
+      "url": "https://pokeapi.co/api/v2/berry/3/"
+    }
+  ],
+  "names": [
+    {
+      "name": "Very Soft",
+      "language": {
+        "name": "en",
+        "url": "https://pokeapi.co/api/v2/language/9/"
+      }
+    }
+  ]
+}

--- a/examples/pokeapi/pokeapi-berry/src/main/resources/berry-flavor.json
+++ b/examples/pokeapi/pokeapi-berry/src/main/resources/berry-flavor.json
@@ -1,0 +1,26 @@
+{
+  "id": 1,
+  "name": "spicy",
+  "berries": [
+    {
+      "potency": 10,
+      "berry": {
+        "name": "rowap",
+        "url": "https://pokeapi.co/api/v2/berry/64/"
+      }
+    }
+  ],
+  "contest_type": {
+    "name": "cool",
+    "url": "https://pokeapi.co/api/v2/contest-type/1/"
+  },
+  "names": [
+    {
+      "name": "Spicy",
+      "language": {
+        "name": "en",
+        "url": "https://pokeapi.co/api/v2/language/9/"
+      }
+    }
+  ]
+}

--- a/examples/pokeapi/pokeapi-gateway/endpoints/berry.conf
+++ b/examples/pokeapi/pokeapi-gateway/endpoints/berry.conf
@@ -11,6 +11,28 @@ tollgate {
         }
       }
     }
+    getBerryFirmness {
+      method = "GET"
+      path = "/api/v2/berry-firmness/{idOrName}"
+      upstream {
+        service = ${tollgate.services.berry}
+        endpoint {
+          method = "GET"
+          path = "/berry-firmness/{idOrName}"
+        }
+      }
+    }
+    getBerryFlavor {
+      method = "GET"
+      path = "/api/v2/berry-flavor/{idOrName}"
+      upstream {
+        service = ${tollgate.services.berry}
+        endpoint {
+          method = "GET"
+          path = "/berry-flavor/{idOrName}"
+        }
+      }
+    }
   }
   services {
     berry {


### PR DESCRIPTION
### Motivation

To confirm there can be multi endpoints which have same upstream.

### Description

Add other `pokeapi-berry` endpoints (`getBerryFirmness` and `getBerryFlavor`) to `pokeapi-gateway` configuration.
