### PR TITLE
Rename `Main` instance in `Main#main` to `main`

### DIFF
--- a/standalone/src/main/java/dev/gihwan/tollgate/standalone/Main.java
+++ b/standalone/src/main/java/dev/gihwan/tollgate/standalone/Main.java
@@ -132,18 +132,18 @@ public final class Main {
     }
 
     public static void main(String[] args) {
-        final Main server = new Main();
+        final Main main = new Main();
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
-                server.stop();
+                main.stop();
             } catch (Exception e) {
                 logger.error("Failed to stop the Tollgate standalone.", e);
             }
         }));
 
         try {
-            server.start();
+            main.start();
         } catch (Exception e) {
             logger.error("Failed to start the Tollgate standalone.", e);
             System.exit(-1);


### PR DESCRIPTION
### Motivation

The name of `Main` instance in `Main#main` is wrong, `server`.

### Description

Change to `main`
