### PR TITLE
Make services implement `UpstreamHttpService` instead of `HttpService`

### DIFF
--- a/core/src/main/java/dev/gihwan/tollgate/core/Tollgate.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/Tollgate.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
 
-import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -42,6 +41,7 @@ import com.linecorp.armeria.server.healthcheck.SettableHealthChecker;
 import com.linecorp.armeria.server.logging.LoggingService;
 
 import dev.gihwan.tollgate.core.server.RemappingRequestHeadersService;
+import dev.gihwan.tollgate.core.server.UpstreamHttpService;
 import dev.gihwan.tollgate.core.server.UpstreamRegistry;
 
 public final class Tollgate {
@@ -86,7 +86,7 @@ public final class Tollgate {
         config.endpoints().forEach(endpointConfig -> {
             logger.info("Registering endpoint {}.", endpointConfig);
 
-            HttpService upstreamService = UpstreamRegistry.instance().get(endpointConfig.upstream());
+            UpstreamHttpService upstreamService = UpstreamRegistry.instance().get(endpointConfig.upstream());
 
             if (!Strings.isNullOrEmpty(endpointConfig.path())) {
                 final String pathPattern = endpointConfig.path();

--- a/core/src/main/java/dev/gihwan/tollgate/core/server/DefaultUpstreamHttpService.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/server/DefaultUpstreamHttpService.java
@@ -41,11 +41,11 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 import dev.gihwan.tollgate.core.service.Service;
 
-final class DefaultUpstreamService implements UpstreamService {
+final class DefaultUpstreamHttpService implements UpstreamHttpService {
 
     private final Service service;
 
-    DefaultUpstreamService(Service service) {
+    DefaultUpstreamHttpService(Service service) {
         this.service = requireNonNull(service, "service");
     }
 

--- a/core/src/main/java/dev/gihwan/tollgate/core/server/RemappingRequestHeadersService.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/server/RemappingRequestHeadersService.java
@@ -43,9 +43,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 
-public final class RemappingRequestHeadersService extends SimpleDecoratingHttpService {
+public final class RemappingRequestHeadersService extends SimpleDecoratingUpstreamHttpService {
 
     private static final Logger logger = LoggerFactory.getLogger(RemappingRequestHeadersService.class);
 

--- a/core/src/main/java/dev/gihwan/tollgate/core/server/SimpleDecoratingUpstreamHttpService.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/server/SimpleDecoratingUpstreamHttpService.java
@@ -24,33 +24,19 @@
 
 package dev.gihwan.tollgate.core.server;
 
-import static java.util.Objects.requireNonNull;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.SimpleDecoratingService;
 
-import java.util.HashMap;
-import java.util.Map;
+public abstract class SimpleDecoratingUpstreamHttpService
+        extends SimpleDecoratingService<HttpRequest, HttpResponse>
+        implements UpstreamHttpService {
 
-public final class UpstreamRegistry {
-
-    private static final UpstreamRegistry INSTANCE = new UpstreamRegistry();
-
-    public static UpstreamRegistry instance() {
-        return INSTANCE;
-    }
-
-    private final Map<UpstreamConfig, UpstreamHttpService> upstreams = new HashMap<>();
-
-    private UpstreamRegistry() {}
-
-    public UpstreamHttpService get(UpstreamConfig config) {
-        requireNonNull(config, "config");
-
-        final UpstreamHttpService upstreamService = upstreams.get(config);
-        if (upstreamService != null) {
-            return upstreamService;
-        }
-
-        final UpstreamHttpService newUpstreamService = UpstreamHttpService.of(config);
-        upstreams.put(config, newUpstreamService);
-        return newUpstreamService;
+    /**
+     * Creates a new instance that decorates the specified {@link Service}.
+     */
+    protected SimpleDecoratingUpstreamHttpService(Service<HttpRequest, HttpResponse> delegate) {
+        super(delegate);
     }
 }

--- a/core/src/main/java/dev/gihwan/tollgate/core/server/UpstreamHttpService.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/server/UpstreamHttpService.java
@@ -31,11 +31,11 @@ import com.linecorp.armeria.server.HttpService;
 import dev.gihwan.tollgate.core.service.Service;
 import dev.gihwan.tollgate.core.service.ServiceFactory;
 
-public interface UpstreamService extends HttpService {
+public interface UpstreamHttpService extends HttpService {
 
-    static UpstreamService of(UpstreamConfig config) {
+    static UpstreamHttpService of(UpstreamConfig config) {
         requireNonNull(config, "config");
         final Service service = ServiceFactory.instance().get(config.service());
-        return new DefaultUpstreamService(service);
+        return new DefaultUpstreamHttpService(service);
     }
 }

--- a/core/src/test/java/dev/gihwan/tollgate/core/server/DefaultUpstreamHttpServiceTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/server/DefaultUpstreamHttpServiceTest.java
@@ -46,7 +46,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import dev.gihwan.tollgate.core.service.Service;
 import dev.gihwan.tollgate.core.service.ServiceConfig;
 
-class DefaultUpstreamServiceTest {
+class DefaultUpstreamHttpServiceTest {
 
     private static final AtomicReference<AggregatedHttpRequest> reqCapture = new AtomicReference<>();
 
@@ -69,7 +69,7 @@ class DefaultUpstreamServiceTest {
             final ServiceConfig serviceConfig = ServiceConfig.of(serviceServer.httpUri().toString());
             final Service service = Service.of(serviceConfig);
 
-            sb.service("/foo", new DefaultUpstreamService(service));
+            sb.service("/foo", new DefaultUpstreamHttpService(service));
         }
     };
 

--- a/core/src/test/java/dev/gihwan/tollgate/core/server/RemappingHttpPathServiceTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/server/RemappingHttpPathServiceTest.java
@@ -59,7 +59,7 @@ class RemappingHttpPathServiceTest {
             final ServiceConfig serviceConfig = ServiceConfig.of(serviceServer.httpUri().toString());
             final Service service = Service.of(serviceConfig);
 
-            sb.service("/foo", new DefaultUpstreamService(service)
+            sb.service("/foo", new DefaultUpstreamHttpService(service)
                     .decorate(RemappingRequestHeadersService.newDecorator("/bar")));
         }
     };


### PR DESCRIPTION
### Motivation

To prepare providing a builder not based on configuration.

### Description

 - Rename `UpstreamService` to `UpstreamHttpService`
 - Add `SimpleDecoratingUpstreamHttpService`
 - Make `RemappingRequestHeadersService` extends `SimpleDecoratingUpstreamHttpService`
