### PR TITLE
Rename `Service` to `UpstreamClient` and move to `client` package

### DIFF
--- a/core/src/main/java/dev/gihwan/tollgate/core/client/Authority.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/client/Authority.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.core.service;
+package dev.gihwan.tollgate.core.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;

--- a/core/src/main/java/dev/gihwan/tollgate/core/client/DefaultUpstreamClient.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/client/DefaultUpstreamClient.java
@@ -22,35 +22,27 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.core.service;
+package dev.gihwan.tollgate.core.client;
 
-import static java.util.Objects.requireNonNull;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
 
-import java.util.HashMap;
-import java.util.Map;
+final class DefaultUpstreamClient implements UpstreamClient {
 
-public final class ServiceFactory {
+    private final ServiceConfig config;
+    private final WebClient client;
 
-    private static final ServiceFactory INSTANCE = new ServiceFactory();
-
-    public static ServiceFactory instance() {
-        return INSTANCE;
+    DefaultUpstreamClient(ServiceConfig config) {
+        this.config = config;
+        client = config.webClientBuilder()
+                       .decorator(LoggingClient.newDecorator())
+                       .build();
     }
 
-    private final Map<ServiceConfig, Service> services = new HashMap<>();
-
-    private ServiceFactory() {}
-
-    public Service get(ServiceConfig config) {
-        requireNonNull(config, "config");
-
-        final Service service = services.get(config);
-        if (service != null) {
-            return service;
-        }
-
-        final Service newService = Service.of(config);
-        services.put(config, newService);
-        return newService;
+    @Override
+    public HttpResponse execute(HttpRequest req) {
+        return client.execute(req);
     }
 }

--- a/core/src/main/java/dev/gihwan/tollgate/core/client/ServiceConfig.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/client/ServiceConfig.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.core.service;
+package dev.gihwan.tollgate.core.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;

--- a/core/src/main/java/dev/gihwan/tollgate/core/client/UpstreamClient.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/client/UpstreamClient.java
@@ -22,7 +22,19 @@
  * SOFTWARE.
  */
 
-@NonNullByDefault
-package dev.gihwan.tollgate.core.service;
+package dev.gihwan.tollgate.core.client;
 
-import dev.gihwan.tollgate.core.annotation.NonNullByDefault;
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+
+public interface UpstreamClient {
+
+    static UpstreamClient of(ServiceConfig config) {
+        requireNonNull(config, "config");
+        return new DefaultUpstreamClient(config);
+    }
+
+    HttpResponse execute(HttpRequest req);
+}

--- a/core/src/main/java/dev/gihwan/tollgate/core/client/package-info.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/client/package-info.java
@@ -22,19 +22,7 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.core.service;
+@NonNullByDefault
+package dev.gihwan.tollgate.core.client;
 
-import static java.util.Objects.requireNonNull;
-
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
-
-public interface Service {
-
-    static Service of(ServiceConfig config) {
-        requireNonNull(config, "config");
-        return new DefaultService(config);
-    }
-
-    HttpResponse send(HttpRequest req);
-}
+import dev.gihwan.tollgate.core.annotation.NonNullByDefault;

--- a/core/src/main/java/dev/gihwan/tollgate/core/server/DefaultUpstreamService.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/server/DefaultUpstreamService.java
@@ -39,14 +39,14 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-import dev.gihwan.tollgate.core.service.Service;
+import dev.gihwan.tollgate.core.client.UpstreamClient;
 
 final class DefaultUpstreamService implements UpstreamService {
 
-    private final Service service;
+    private final UpstreamClient client;
 
-    DefaultUpstreamService(Service service) {
-        this.service = requireNonNull(service, "service");
+    DefaultUpstreamService(UpstreamClient client) {
+        this.client = requireNonNull(client, "client");
     }
 
     @Override
@@ -64,7 +64,7 @@ final class DefaultUpstreamService implements UpstreamService {
     private HttpResponse sendRequest(HttpRequest req) {
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
         final HttpResponse res = HttpResponse.from(responseFuture);
-        service.send(req).aggregate().handle((aggregated, t) -> {
+        client.execute(req).aggregate().handle((aggregated, t) -> {
             if (t != null) {
                 resolveException(responseFuture, t);
                 return null;

--- a/core/src/main/java/dev/gihwan/tollgate/core/server/UpstreamConfig.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/server/UpstreamConfig.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import dev.gihwan.tollgate.core.service.ServiceConfig;
+import dev.gihwan.tollgate.core.client.ServiceConfig;
 
 public final class UpstreamConfig {
 

--- a/core/src/main/java/dev/gihwan/tollgate/core/server/UpstreamService.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/server/UpstreamService.java
@@ -28,14 +28,14 @@ import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.server.HttpService;
 
-import dev.gihwan.tollgate.core.service.Service;
-import dev.gihwan.tollgate.core.service.ServiceFactory;
+import dev.gihwan.tollgate.core.client.UpstreamClient;
+import dev.gihwan.tollgate.core.client.UpstreamClientFactory;
 
 public interface UpstreamService extends HttpService {
 
     static UpstreamService of(UpstreamConfig config) {
         requireNonNull(config, "config");
-        final Service service = ServiceFactory.instance().get(config.service());
-        return new DefaultUpstreamService(service);
+        final UpstreamClient upstreamClient = UpstreamClientFactory.instance().get(config.service());
+        return new DefaultUpstreamService(upstreamClient);
     }
 }

--- a/core/src/test/java/dev/gihwan/tollgate/core/client/AuthorityTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/client/AuthorityTest.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.core.service;
+package dev.gihwan.tollgate.core.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/core/src/test/java/dev/gihwan/tollgate/core/client/ServiceConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/client/ServiceConfigTest.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.core.service;
+package dev.gihwan.tollgate.core.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/core/src/test/java/dev/gihwan/tollgate/core/server/DefaultUpstreamServiceTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/server/DefaultUpstreamServiceTest.java
@@ -43,8 +43,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-import dev.gihwan.tollgate.core.service.Service;
-import dev.gihwan.tollgate.core.service.ServiceConfig;
+import dev.gihwan.tollgate.core.client.UpstreamClient;
+import dev.gihwan.tollgate.core.client.ServiceConfig;
 
 class DefaultUpstreamServiceTest {
 
@@ -67,9 +67,9 @@ class DefaultUpstreamServiceTest {
         @Override
         protected void configure(ServerBuilder sb) {
             final ServiceConfig serviceConfig = ServiceConfig.of(serviceServer.httpUri().toString());
-            final Service service = Service.of(serviceConfig);
+            final UpstreamClient client = UpstreamClient.of(serviceConfig);
 
-            sb.service("/foo", new DefaultUpstreamService(service));
+            sb.service("/foo", new DefaultUpstreamService(client));
         }
     };
 

--- a/core/src/test/java/dev/gihwan/tollgate/core/server/EndpointConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/server/EndpointConfigTest.java
@@ -31,10 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpMethod;
 
-import dev.gihwan.tollgate.core.server.EndpointConfig;
-import dev.gihwan.tollgate.core.service.ServiceConfig;
-import dev.gihwan.tollgate.core.server.UpstreamConfig;
-import dev.gihwan.tollgate.core.server.UpstreamEndpointConfig;
+import dev.gihwan.tollgate.core.client.ServiceConfig;
 
 @SuppressWarnings("ConstantConditions")
 class EndpointConfigTest {

--- a/core/src/test/java/dev/gihwan/tollgate/core/server/RemappingHttpPathServiceTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/server/RemappingHttpPathServiceTest.java
@@ -33,8 +33,8 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-import dev.gihwan.tollgate.core.service.Service;
-import dev.gihwan.tollgate.core.service.ServiceConfig;
+import dev.gihwan.tollgate.core.client.ServiceConfig;
+import dev.gihwan.tollgate.core.client.UpstreamClient;
 
 class RemappingHttpPathServiceTest {
 
@@ -57,9 +57,9 @@ class RemappingHttpPathServiceTest {
         @Override
         protected void configure(ServerBuilder sb) {
             final ServiceConfig serviceConfig = ServiceConfig.of(serviceServer.httpUri().toString());
-            final Service service = Service.of(serviceConfig);
+            final UpstreamClient client = UpstreamClient.of(serviceConfig);
 
-            sb.service("/foo", new DefaultUpstreamService(service)
+            sb.service("/foo", new DefaultUpstreamService(client)
                     .decorate(RemappingRequestHeadersService.newDecorator("/bar")));
         }
     };

--- a/core/src/test/java/dev/gihwan/tollgate/core/server/UpstreamConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/server/UpstreamConfigTest.java
@@ -31,9 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpMethod;
 
-import dev.gihwan.tollgate.core.server.UpstreamConfig;
-import dev.gihwan.tollgate.core.server.UpstreamEndpointConfig;
-import dev.gihwan.tollgate.core.service.ServiceConfig;
+import dev.gihwan.tollgate.core.client.ServiceConfig;
 
 @SuppressWarnings("ConstantConditions")
 class UpstreamConfigTest {

--- a/standalone/src/main/java/dev/gihwan/tollgate/standalone/Main.java
+++ b/standalone/src/main/java/dev/gihwan/tollgate/standalone/Main.java
@@ -46,8 +46,8 @@ import dev.gihwan.tollgate.core.TollgateBuilder;
 import dev.gihwan.tollgate.core.server.EndpointConfig;
 import dev.gihwan.tollgate.core.server.UpstreamConfig;
 import dev.gihwan.tollgate.core.server.UpstreamEndpointConfig;
-import dev.gihwan.tollgate.core.service.Authority;
-import dev.gihwan.tollgate.core.service.ServiceConfig;
+import dev.gihwan.tollgate.core.client.Authority;
+import dev.gihwan.tollgate.core.client.ServiceConfig;
 
 public final class Main {
 


### PR DESCRIPTION
### Motivation

To prevent possible confusion with the `HttpService` in Armeria.

### Description

 - Rename `Service` to `UpstreamClient`
 - Move `UpstreamClient` to `dev.gihwan.tollgate.core.client` package
