### PR TITLE
Rename endpoint to route

### DIFF
--- a/core/src/main/java/dev/gihwan/tollgate/core/Tollgate.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/Tollgate.java
@@ -83,20 +83,20 @@ public final class Tollgate {
         builder.serviceUnder("/docs", DocService.builder().build());
         builder.service(config.healthCheckPath(), HealthCheckService.of(healthChecker));
 
-        config.endpoints().forEach(endpointConfig -> {
-            logger.info("Registering endpoint {}.", endpointConfig);
+        config.routes().forEach(route -> {
+            logger.info("Registering route {}.", route);
 
-            HttpService upstreamService = UpstreamRegistry.instance().get(endpointConfig.upstream());
+            HttpService upstreamService = UpstreamRegistry.instance().get(route.upstream());
 
-            if (!Strings.isNullOrEmpty(endpointConfig.path())) {
-                final String pathPattern = endpointConfig.path();
+            if (!Strings.isNullOrEmpty(route.path())) {
+                final String pathPattern = route.path();
                 upstreamService = upstreamService.decorate(
                         RemappingRequestHeadersService.newDecorator(pathPattern));
             }
 
             builder.service(Route.builder()
-                                 .methods(endpointConfig.method())
-                                 .path(endpointConfig.path())
+                                 .methods(route.method())
+                                 .path(route.path())
                                  .build(),
                             upstreamService.decorate(LoggingService.newDecorator()));
         });

--- a/core/src/main/java/dev/gihwan/tollgate/core/TollgateBuilder.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/TollgateBuilder.java
@@ -29,13 +29,13 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import dev.gihwan.tollgate.core.server.EndpointConfig;
+import dev.gihwan.tollgate.core.server.RouteConfig;
 
 public final class TollgateBuilder {
 
     private int port = 8080;
     private String healthCheckPath = "/health";
-    private final List<EndpointConfig> endpoints = new ArrayList<>();
+    private final List<RouteConfig> routes = new ArrayList<>();
 
     TollgateBuilder() {}
 
@@ -50,9 +50,9 @@ public final class TollgateBuilder {
         return this;
     }
 
-    public TollgateBuilder endpoint(EndpointConfig endpoint) {
-        requireNonNull(endpoint, "endpoint");
-        endpoints.add(endpoint);
+    public TollgateBuilder route(RouteConfig route) {
+        requireNonNull(route, "route");
+        routes.add(route);
         return this;
     }
 
@@ -61,6 +61,6 @@ public final class TollgateBuilder {
     }
 
     private TollgateConfig buildConfig() {
-        return new TollgateConfig(port, healthCheckPath, endpoints);
+        return new TollgateConfig(port, healthCheckPath, routes);
     }
 }

--- a/core/src/main/java/dev/gihwan/tollgate/core/TollgateConfig.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/TollgateConfig.java
@@ -31,22 +31,22 @@ import java.util.List;
 
 import com.google.common.base.MoreObjects;
 
-import dev.gihwan.tollgate.core.server.EndpointConfig;
+import dev.gihwan.tollgate.core.server.RouteConfig;
 
 public final class TollgateConfig {
 
     private final int port;
     private final String healthCheckPath;
-    private final List<EndpointConfig> endpoints;
+    private final List<RouteConfig> routes;
 
-    TollgateConfig(int port, String healthCheckPath, List<EndpointConfig> endpoints) {
+    TollgateConfig(int port, String healthCheckPath, List<RouteConfig> routes) {
         checkArgument(port >= 0, "port: %s (expected: >= 0)", port);
         checkArgument(port <= 65535, "port: %s (expected: <= 65535)", port);
         this.port = port;
         requireNonNull(healthCheckPath, "healthCheckPath");
         this.healthCheckPath = healthCheckPath;
-        requireNonNull(endpoints, "endpoints");
-        this.endpoints = endpoints;
+        requireNonNull(routes, "routes");
+        this.routes = routes;
     }
 
     public int port() {
@@ -57,8 +57,8 @@ public final class TollgateConfig {
         return healthCheckPath;
     }
 
-    public List<EndpointConfig> endpoints() {
-        return endpoints;
+    public List<RouteConfig> routes() {
+        return routes;
     }
 
     @Override
@@ -66,7 +66,7 @@ public final class TollgateConfig {
         return MoreObjects.toStringHelper(this)
                           .add("port", port)
                           .add("healthCheckPath", healthCheckPath)
-                          .add("endpoints", endpoints)
+                          .add("routes", routes)
                           .toString();
     }
 }

--- a/core/src/main/java/dev/gihwan/tollgate/core/server/RouteConfig.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/server/RouteConfig.java
@@ -33,17 +33,17 @@ import com.google.common.base.Objects;
 
 import com.linecorp.armeria.common.HttpMethod;
 
-public final class EndpointConfig {
+public final class RouteConfig {
 
-    public static EndpointConfig of(HttpMethod method, String path, UpstreamConfig upstream) {
-        return new EndpointConfig(method, path, upstream);
+    public static RouteConfig of(HttpMethod method, String path, UpstreamConfig upstream) {
+        return new RouteConfig(method, path, upstream);
     }
 
     private final HttpMethod method;
     private final String path;
     private final UpstreamConfig upstream;
 
-    private EndpointConfig(HttpMethod method, String path, UpstreamConfig upstream) {
+    private RouteConfig(HttpMethod method, String path, UpstreamConfig upstream) {
         this.method = requireNonNull(method, "method");
         this.path = requireNonNull(path, "path");
         this.upstream = requireNonNull(upstream, "upstream");
@@ -67,11 +67,11 @@ public final class EndpointConfig {
             return true;
         }
 
-        if (!(o instanceof EndpointConfig)) {
+        if (!(o instanceof RouteConfig)) {
             return false;
         }
 
-        final EndpointConfig that = (EndpointConfig) o;
+        final RouteConfig that = (RouteConfig) o;
         return Objects.equal(method, that.method) &&
                Objects.equal(path, that.path) &&
                Objects.equal(upstream, that.upstream);

--- a/core/src/test/java/dev/gihwan/tollgate/core/server/RouteConfigTest.java
+++ b/core/src/test/java/dev/gihwan/tollgate/core/server/RouteConfigTest.java
@@ -34,20 +34,20 @@ import com.linecorp.armeria.common.HttpMethod;
 import dev.gihwan.tollgate.core.client.ServiceConfig;
 
 @SuppressWarnings("ConstantConditions")
-class EndpointConfigTest {
+class RouteConfigTest {
 
     @Test
     void of() {
-        assertThatThrownBy(() -> EndpointConfig.of(null, null, null))
+        assertThatThrownBy(() -> RouteConfig.of(null, null, null))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> EndpointConfig.of(null, "/api", newUpstreamConfig()))
+        assertThatThrownBy(() -> RouteConfig.of(null, "/api", newUpstreamConfig()))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> EndpointConfig.of(HttpMethod.GET, null, newUpstreamConfig()))
+        assertThatThrownBy(() -> RouteConfig.of(HttpMethod.GET, null, newUpstreamConfig()))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> EndpointConfig.of(HttpMethod.GET, "/api", null))
+        assertThatThrownBy(() -> RouteConfig.of(HttpMethod.GET, "/api", null))
                 .isInstanceOf(NullPointerException.class);
 
-        final EndpointConfig config = EndpointConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
+        final RouteConfig config = RouteConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
         assertThat(config.method()).isEqualTo(HttpMethod.GET);
         assertThat(config.path()).isEqualTo("/api");
         assertThat(config.upstream()).isEqualTo(newUpstreamConfig());
@@ -56,13 +56,13 @@ class EndpointConfigTest {
     @SuppressWarnings("EqualsBetweenInconvertibleTypes")
     @Test
     void equals() {
-        final EndpointConfig config = EndpointConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
+        final RouteConfig config = RouteConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
 
-        final EndpointConfig same = EndpointConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
-        final EndpointConfig differentMethod = EndpointConfig.of(HttpMethod.POST, "/api", newUpstreamConfig());
-        final EndpointConfig differentPath = EndpointConfig.of(HttpMethod.GET, "/api/v1", newUpstreamConfig());
-        final EndpointConfig differentUpstream =
-                EndpointConfig.of(HttpMethod.GET, "/api", newUpstreamConfig("http://example.org"));
+        final RouteConfig same = RouteConfig.of(HttpMethod.GET, "/api", newUpstreamConfig());
+        final RouteConfig differentMethod = RouteConfig.of(HttpMethod.POST, "/api", newUpstreamConfig());
+        final RouteConfig differentPath = RouteConfig.of(HttpMethod.GET, "/api/v1", newUpstreamConfig());
+        final RouteConfig differentUpstream =
+                RouteConfig.of(HttpMethod.GET, "/api", newUpstreamConfig("http://example.org"));
 
         assertThat(config.equals(same)).isTrue();
         assertThat(config.equals(differentMethod)).isFalse();

--- a/examples/pokeapi/pokeapi-gateway/Dockerfile
+++ b/examples/pokeapi/pokeapi-gateway/Dockerfile
@@ -3,10 +3,10 @@ FROM ghkim3221/tollgate-standalone
 ENV TOLLGATE_HOME "/opt/tollgate"
 
 RUN mkdir -p "$TOLLGATE_HOME"
-RUN mkdir -p "$TOLLGATE_HOME/endpoints"
+RUN mkdir -p "$TOLLGATE_HOME/routing"
 
 COPY *.conf "$TOLLGATE_HOME"
-COPY endpoints/*.conf "$TOLLGATE_HOME/endpoints/"
+COPY routing "$TOLLGATE_HOME/routing/"
 
 WORKDIR "$TOLLGATE_HOME"
 

--- a/examples/pokeapi/pokeapi-gateway/application.conf
+++ b/examples/pokeapi/pokeapi-gateway/application.conf
@@ -3,13 +3,13 @@ tollgate {
   healthCheckPath = "/health"
 }
 
-include required(file("endpoints/berry.conf"))
-include required(file("endpoints/contest.conf"))
-include required(file("endpoints/encounter.conf"))
-include required(file("endpoints/evolution.conf"))
-include required(file("endpoints/game.conf"))
-include required(file("endpoints/item.conf"))
-include required(file("endpoints/location.conf"))
-include required(file("endpoints/machine.conf"))
-include required(file("endpoints/move.conf"))
-include required(file("endpoints/pokemon.conf"))
+include required(file("/routing/berry.conf"))
+include required(file("/routing/contest.conf"))
+include required(file("/routing/encounter.conf"))
+include required(file("/routing/evolution.conf"))
+include required(file("/routing/game.conf"))
+include required(file("/routing/item.conf"))
+include required(file("/routing/location.conf"))
+include required(file("/routing/machine.conf"))
+include required(file("/routing/move.conf"))
+include required(file("/routing/pokemon.conf"))

--- a/examples/pokeapi/pokeapi-gateway/routing/berry.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/berry.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getBerry {
       method = "GET"
       path = "/api/v2/berry/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/contest.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/contest.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getContestType {
       method = "GET"
       path = "/api/v2/contest-type/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/encounter.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/encounter.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getEncounterMethod {
       method = "GET"
       path = "/api/v2/encounter-method/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/evolution.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/evolution.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getEvolutionChain {
       method = "GET"
       path = "/api/v2/evolution-chain/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/game.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/game.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getGeneration {
       method = "GET"
       path = "/api/v2/generation/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/item.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/item.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getItem {
       method = "GET"
       path = "/api/v2/item/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/location.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/location.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getLocation {
       method = "GET"
       path = "/api/v2/location/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/machine.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/machine.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getMachine {
       method = "GET"
       path = "/api/v2/machine/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/move.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/move.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getMove {
       method = "GET"
       path = "/api/v2/move/{idOrName}"

--- a/examples/pokeapi/pokeapi-gateway/routing/pokemon.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/pokemon.conf
@@ -1,5 +1,5 @@
 tollgate {
-  endpoints {
+  routing {
     getAbility {
       method = "GET"
       path = "/api/v2/ability/{idOrName}"

--- a/standalone/src/main/resources/reference.conf
+++ b/standalone/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 tollgate {
   port = 8080
   healthCheckPath = "/health"
-  endpoints {}
+  routing {}
 }


### PR DESCRIPTION
### Motivation

#67

### Description

Rename `endpoint` to `route` and `endpoints` in configuration to `routing`.

### Result

 - Close #67
