### PR TITLE
Do not bind `HealthCheckService` if `healthCheckPath` is null or empty

### DIFF
--- a/core/src/main/java/dev/gihwan/tollgate/core/Tollgate.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/Tollgate.java
@@ -81,7 +81,10 @@ public final class Tollgate {
 
         builder.http(config.port());
         builder.serviceUnder("/docs", DocService.builder().build());
-        builder.service(config.healthCheckPath(), HealthCheckService.of(healthChecker));
+
+        if (!Strings.isNullOrEmpty(config.healthCheckPath())) {
+            builder.service(config.healthCheckPath(), HealthCheckService.of(healthChecker));
+        }
 
         config.routes().forEach(route -> {
             logger.info("Registering route {}.", route);


### PR DESCRIPTION
### Motivation

To provide a way to disable `HealthCheckService`.

### Description

If `healthCheckPath` is `null` or empty, do not bind `HealthCheckService`.

### Result

Users can disable `HealthCheckService` by setting `healthCheckPath` null or empty.
