### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
  */
 
 plugins {
-    id("com.google.cloud.tools.jib") version "2.5.0" apply false
+    id("com.google.cloud.tools.jib") version "2.7.0" apply false
 }
 
 allprojects {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,17 +27,17 @@ plugins {
 }
 
 dependencies {
-    api("com.linecorp.armeria:armeria:1.1.0")
-    implementation("com.google.guava:guava:29.0-jre")
+    api("com.linecorp.armeria:armeria:1.3.0")
+    implementation("com.google.guava:guava:30.1-jre")
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("org.apache.commons:commons-lang3:3.11")
     implementation("org.slf4j:slf4j-api:1.7.30")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
-    testImplementation("org.assertj:assertj-core:3.17.2")
-    testImplementation("org.mockito:mockito-core:3.5.13")
+    testImplementation("org.assertj:assertj-core:3.18.1")
+    testImplementation("org.mockito:mockito-core:3.7.0")
     testImplementation("org.awaitility:awaitility:4.0.3")
-    testImplementation("com.linecorp.armeria:armeria-junit5:1.1.0")
+    testImplementation("com.linecorp.armeria:armeria-junit5:1.3.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
     testRuntimeOnly("ch.qos.logback:logback-classic:1.2.3")

--- a/examples/pokeapi/pokeapi-berry/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-berry/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-contest/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-contest/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-encounter/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-encounter/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-evolution/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-evolution/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-game/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-game/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-item/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-item/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-location/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-location/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-machine/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-machine/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-move/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-move/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/examples/pokeapi/pokeapi-pokemon/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-pokemon/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.1.0")
+    implementation("com.linecorp.armeria:armeria:1.3.0")
 
     implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@ plugins {
 dependencies {
     implementation(project(":core"))
 
-    implementation("com.typesafe:config:1.4.0")
+    implementation("com.typesafe:config:1.4.1")
 
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("org.slf4j:slf4j-api:1.7.30")
@@ -39,10 +39,10 @@ dependencies {
     runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
-    testImplementation("org.assertj:assertj-core:3.17.2")
-    testImplementation("org.mockito:mockito-core:3.5.13")
+    testImplementation("org.assertj:assertj-core:3.18.1")
+    testImplementation("org.mockito:mockito-core:3.7.0")
     testImplementation("org.awaitility:awaitility:4.0.3")
-    testImplementation("com.linecorp.armeria:armeria-junit5:1.1.0")
+    testImplementation("com.linecorp.armeria:armeria-junit5:1.3.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
 }


### PR DESCRIPTION
Update dependencies:
 - Bump jib from 2.5.0 to 2.7.0
 - Bump armeria from 1.1.0 to 1.3.0
 - Bump guava from 29.0-jre to 30.1-jre
 - Bump assertj-core from 3.17.2 to 3.18.1
 - Bump mockito-core from 3.5.13 to 3.7.0