### PR TITLE
Manage dependencies in `buildSrc`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,29 +22,10 @@
  * SOFTWARE.
  */
 
-import dev.gihwan.tollgate.Dependency
-
 plugins {
-    java
-    application
-    id("com.google.cloud.tools.jib")
+    `kotlin-dsl`
 }
 
-dependencies {
-    implementation(Dependency.armeria)
-
-    implementation(Dependency.slf4j)
-
-    runtimeOnly(Dependency.logback)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-jib {
-    to {
-        image = "pokeapi-item"
-    }
+repositories {
+    jcenter()
 }

--- a/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Dependency.kt
+++ b/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Dependency.kt
@@ -22,29 +22,22 @@
  * SOFTWARE.
  */
 
-import dev.gihwan.tollgate.Dependency
+package dev.gihwan.tollgate
 
-plugins {
-    java
-    application
-    id("com.google.cloud.tools.jib")
-}
+object Dependency {
+    const val armeria = "com.linecorp.armeria:armeria:${Version.armeria}"
+    const val armeriaJunit = "com.linecorp.armeria:armeria-junit5:${Version.armeria}"
 
-dependencies {
-    implementation(Dependency.armeria)
+    const val commonsLang3 = "org.apache.commons:commons-lang3:${Version.commonsLang3}"
+    const val config = "com.typesafe:config:${Version.config}"
+    const val guava = "com.google.guava:guava:${Version.guava}"
+    const val jsr305 = "com.google.code.findbugs:jsr305:${Version.jsr305}"
+    const val logback = "ch.qos.logback:logback-classic:${Version.logback}"
+    const val slf4j = "org.slf4j:slf4j-api:${Version.slf4j}"
 
-    implementation(Dependency.slf4j)
-
-    runtimeOnly(Dependency.logback)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-jib {
-    to {
-        image = "pokeapi-item"
-    }
+    const val assertj = "org.assertj:assertj-core:${Version.assertj}"
+    const val awaitility = "org.awaitility:awaitility:${Version.awaitility}"
+    const val junitApi = "org.junit.jupiter:junit-jupiter-api:${Version.junit}"
+    const val junitEngine = "org.junit.jupiter:junit-jupiter-engine:${Version.junit}"
+    const val mockito = "org.mockito:mockito-core:${Version.mockito}"
 }

--- a/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
+++ b/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
@@ -22,29 +22,20 @@
  * SOFTWARE.
  */
 
-import dev.gihwan.tollgate.Dependency
+package dev.gihwan.tollgate
 
-plugins {
-    java
-    application
-    id("com.google.cloud.tools.jib")
-}
+object Version {
+    const val armeria = "1.3.0"
 
-dependencies {
-    implementation(Dependency.armeria)
+    const val commonsLang3 = "3.11"
+    const val config = "1.4.1"
+    const val guava = "30.1-jre"
+    const val jsr305 = "3.0.2"
+    const val logback = "1.2.3"
+    const val slf4j = "1.7.30"
 
-    implementation(Dependency.slf4j)
-
-    runtimeOnly(Dependency.logback)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-jib {
-    to {
-        image = "pokeapi-item"
-    }
+    const val assertj = "3.18.1"
+    const val awaitility = "4.0.3"
+    const val junit = "5.7.0"
+    const val mockito = "3.7.0"
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,25 +22,27 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     id("java-library")
 }
 
 dependencies {
-    api("com.linecorp.armeria:armeria:1.3.0")
-    implementation("com.google.guava:guava:30.1-jre")
-    implementation("com.google.code.findbugs:jsr305:3.0.2")
-    implementation("org.apache.commons:commons-lang3:3.11")
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    api(Dependency.armeria)
+    implementation(Dependency.commonsLang3)
+    implementation(Dependency.guava)
+    implementation(Dependency.jsr305)
+    implementation(Dependency.slf4j)
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
-    testImplementation("org.assertj:assertj-core:3.18.1")
-    testImplementation("org.mockito:mockito-core:3.7.0")
-    testImplementation("org.awaitility:awaitility:4.0.3")
-    testImplementation("com.linecorp.armeria:armeria-junit5:1.3.0")
+    testImplementation(Dependency.junitApi)
+    testImplementation(Dependency.assertj)
+    testImplementation(Dependency.awaitility)
+    testImplementation(Dependency.mockito)
+    testImplementation(Dependency.armeriaJunit)
 
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
-    testRuntimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    testRuntimeOnly(Dependency.junitEngine)
+    testRuntimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-berry/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-berry/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-contest/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-contest/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-encounter/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-encounter/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-evolution/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-evolution/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-game/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-game/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-location/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-location/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-machine/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-machine/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-move/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-move/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/examples/pokeapi/pokeapi-pokemon/build.gradle.kts
+++ b/examples/pokeapi/pokeapi-pokemon/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -29,11 +31,11 @@ plugins {
 }
 
 dependencies {
-    implementation("com.linecorp.armeria:armeria:1.3.0")
+    implementation(Dependency.armeria)
 
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation(Dependency.slf4j)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    runtimeOnly(Dependency.logback)
 }
 
 java {

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import dev.gihwan.tollgate.Dependency
+
 plugins {
     java
     application
@@ -31,20 +33,19 @@ plugins {
 dependencies {
     implementation(project(":core"))
 
-    implementation("com.typesafe:config:1.4.1")
+    implementation(Dependency.config)
+    implementation(Dependency.jsr305)
+    implementation(Dependency.slf4j)
 
-    implementation("com.google.code.findbugs:jsr305:3.0.2")
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    runtimeOnly(Dependency.logback)
 
-    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    testImplementation(Dependency.junitApi)
+    testImplementation(Dependency.assertj)
+    testImplementation(Dependency.awaitility)
+    testImplementation(Dependency.mockito)
+    testImplementation(Dependency.armeriaJunit)
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
-    testImplementation("org.assertj:assertj-core:3.18.1")
-    testImplementation("org.mockito:mockito-core:3.7.0")
-    testImplementation("org.awaitility:awaitility:4.0.3")
-    testImplementation("com.linecorp.armeria:armeria-junit5:1.3.0")
-
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
+    testRuntimeOnly(Dependency.junitEngine)
 }
 
 java {


### PR DESCRIPTION
### Motivation

#74 

### Description

Declare dependencies in `buildSrc`.

### Results

 - It's easy to manage dependencies because they are in single file.
 - No longer possible to use the same library of different versions.
 - Closes #74 
