### PR TITLE
Move `NonNullByDefault` to util module

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -29,6 +29,8 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":util"))
+
     api(Dependency.armeria)
     implementation(Dependency.commonsLang3)
     implementation(Dependency.guava)

--- a/core/src/main/java/dev/gihwan/tollgate/core/package-info.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,4 +25,4 @@
 @NonNullByDefault
 package dev.gihwan.tollgate.core;
 
-import dev.gihwan.tollgate.core.annotation.NonNullByDefault;
+import dev.gihwan.tollgate.util.NonNullByDefault;

--- a/core/src/main/java/dev/gihwan/tollgate/core/remapping/package-info.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/remapping/package-info.java
@@ -25,4 +25,4 @@
 @NonNullByDefault
 package dev.gihwan.tollgate.core.remapping;
 
-import dev.gihwan.tollgate.core.annotation.NonNullByDefault;
+import dev.gihwan.tollgate.util.NonNullByDefault;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ rootProject.name = "tollgate"
 
 include("core")
 include("standalone")
+include("util")
 
 include(":examples:pokeapi:pokeapi-berry")
 include(":examples:pokeapi:pokeapi-contest")

--- a/standalone/src/main/java/dev/gihwan/tollgate/standalone/package-info.java
+++ b/standalone/src/main/java/dev/gihwan/tollgate/standalone/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,4 +25,4 @@
 @NonNullByDefault
 package dev.gihwan.tollgate.standalone;
 
-import dev.gihwan.tollgate.core.annotation.NonNullByDefault;
+import dev.gihwan.tollgate.util.NonNullByDefault;

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,26 +22,28 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.core.annotation;
+import dev.gihwan.tollgate.Dependency
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+plugins {
+    id("java-library")
+}
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.meta.TypeQualifierDefault;
+dependencies {
+    implementation(Dependency.jsr305)
 
-/**
- * Indicates the return values, parameters and fields are non-nullable by default. Annotate a package with
- * this annotation and annotate nullable return values, parameters and fields with {@link Nullable}.
- */
-@Nonnull
-@Documented
-@Target(ElementType.PACKAGE)
-@Retention(RetentionPolicy.RUNTIME)
-@TypeQualifierDefault({ ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD })
-public @interface NonNullByDefault {
+    testImplementation(Dependency.junitApi)
+    testImplementation(Dependency.assertj)
+    testImplementation(Dependency.awaitility)
+    testImplementation(Dependency.mockito)
+
+    testRuntimeOnly(Dependency.junitEngine)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/util/src/main/java/dev/gihwan/tollgate/util/NonNullByDefault.java
+++ b/util/src/main/java/dev/gihwan/tollgate/util/NonNullByDefault.java
@@ -22,50 +22,26 @@
  * SOFTWARE.
  */
 
-import dev.gihwan.tollgate.Dependency
+package dev.gihwan.tollgate.util;
 
-plugins {
-    java
-    application
-    id("com.google.cloud.tools.jib")
-}
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-dependencies {
-    implementation(project(":core"))
-    implementation(project(":util"))
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.meta.TypeQualifierDefault;
 
-    implementation(Dependency.config)
-    implementation(Dependency.jsr305)
-    implementation(Dependency.slf4j)
-
-    runtimeOnly(Dependency.logback)
-
-    testImplementation(Dependency.junitApi)
-    testImplementation(Dependency.assertj)
-    testImplementation(Dependency.awaitility)
-    testImplementation(Dependency.mockito)
-    testImplementation(Dependency.armeriaJunit)
-
-    testRuntimeOnly(Dependency.junitEngine)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-jib {
-    from {
-        image = "openjdk:11-jre-slim"
-    }
-    to {
-        image = "ghkim3221/tollgate-standalone"
-    }
-    container {
-        ports = listOf("8080")
-    }
+/**
+ * Indicates the return values, parameters and fields are non-nullable by default. Annotate a package with
+ * this annotation and annotate nullable return values, parameters and fields with {@link Nullable}.
+ */
+@Nonnull
+@Documented
+@Target(ElementType.PACKAGE)
+@Retention(RetentionPolicy.RUNTIME)
+@TypeQualifierDefault({ ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD })
+public @interface NonNullByDefault {
 }


### PR DESCRIPTION
### Motivation

`NonNullByDefault` is not fit to be in `core.annotation` package.

### Descriptions

 - Create `util` module.
 - Move `NonNullByDefault` from `core` to `util` module.
