### PR TITLE
Respond 503 Service Unavailable at `UnprocessedRequestException`

### DIFF
--- a/core/src/main/java/dev/gihwan/tollgate/core/DefaultUpstream.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/DefaultUpstream.java
@@ -24,7 +24,6 @@
 
 package dev.gihwan.tollgate.core;
 
-import java.net.UnknownHostException;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
@@ -82,11 +81,7 @@ final class DefaultUpstream implements Upstream {
 
     private void resolveException(CompletableFuture<HttpResponse> responseFuture, Throwable t) {
         if (t instanceof UnprocessedRequestException) {
-            resolveException(responseFuture, ((UnprocessedRequestException) t).getCause());
-            return;
-        }
-        if (t instanceof UnknownHostException) {
-            responseFuture.complete(HttpResponse.of(HttpStatus.BAD_GATEWAY));
+            responseFuture.complete(HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE));
             return;
         }
         responseFuture.completeExceptionally(t);


### PR DESCRIPTION
### Motivation

 - To fix a bug which `500 Internal Server Error` is responded when upstream connection is refused.

### Description

 - Respond `503 Service Unavailable` when `UnprocessedRequestException` is thrown.

### Result

 - Client will receive `503 Service Unavailable` if their request has not been handled by a upstream server.
