### PR TITLE
Introduce HOCON module

### DIFF
--- a/core/src/main/java/dev/gihwan/tollgate/core/DefaultTollgateBuilder.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/DefaultTollgateBuilder.java
@@ -22,50 +22,36 @@
  * SOFTWARE.
  */
 
-import dev.gihwan.tollgate.Dependency
+package dev.gihwan.tollgate.core;
 
-plugins {
-    java
-    application
-    id("com.google.cloud.tools.jib")
-}
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 
-dependencies {
-    implementation(project(":util"))
-    implementation(project(":core"))
-    implementation(project(":hocon"))
+public final class DefaultTollgateBuilder extends TollgateBuilder {
 
-    implementation(Dependency.jsr305)
-    implementation(Dependency.slf4j)
+    DefaultTollgateBuilder() {}
 
-    runtimeOnly(Dependency.logback)
-
-    testImplementation(Dependency.junitApi)
-    testImplementation(Dependency.assertj)
-    testImplementation(Dependency.awaitility)
-    testImplementation(Dependency.mockito)
-    testImplementation(Dependency.armeriaJunit)
-
-    testRuntimeOnly(Dependency.junitEngine)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-jib {
-    from {
-        image = "openjdk:11-jre-slim"
+    @Override
+    public DefaultTollgateBuilder http(int port) {
+        return (DefaultTollgateBuilder) super.http(port);
     }
-    to {
-        image = "ghkim3221/tollgate-standalone"
+
+    @Override
+    public DefaultTollgateBuilder healthCheck(String healthCheckPath) {
+        return (DefaultTollgateBuilder) super.healthCheck(healthCheckPath);
     }
-    container {
-        ports = listOf("8080")
+
+    @Override
+    public DefaultTollgateBuilder healthCheck(String healthCheckPath, HealthCheckService healthCheckService) {
+        return (DefaultTollgateBuilder) super.healthCheck(healthCheckPath, healthCheckService);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder route() {
+        return new DefaultUpstreamBindingBuilder(this, serverRoute());
+    }
+
+    @Override
+    public DefaultTollgateBuilder upstream(String pathPattern, Upstream upstream) {
+        return (DefaultTollgateBuilder) super.upstream(pathPattern, upstream);
     }
 }

--- a/core/src/main/java/dev/gihwan/tollgate/core/DefaultUpstreamBindingBuilder.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/DefaultUpstreamBindingBuilder.java
@@ -1,0 +1,156 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.core;
+
+import java.util.function.Predicate;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServiceBindingBuilder;
+
+public final class DefaultUpstreamBindingBuilder extends UpstreamBindingBuilder<DefaultTollgateBuilder> {
+
+    DefaultUpstreamBindingBuilder(DefaultTollgateBuilder tollgateBuilder,
+                                  ServiceBindingBuilder serviceBindingBuilder) {
+        super(tollgateBuilder, serviceBindingBuilder);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder path(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.path(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder pathPrefix(String prefix) {
+        return (DefaultUpstreamBindingBuilder) super.pathPrefix(prefix);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder methods(HttpMethod... methods) {
+        return (DefaultUpstreamBindingBuilder) super.methods(methods);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder methods(Iterable<HttpMethod> methods) {
+        return (DefaultUpstreamBindingBuilder) super.methods(methods);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder get(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.get(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder post(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.post(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder put(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.put(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder patch(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.patch(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder delete(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.delete(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder options(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.options(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder head(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.head(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder trace(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.trace(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder connect(String pathPattern) {
+        return (DefaultUpstreamBindingBuilder) super.connect(pathPattern);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder consumes(MediaType... consumeTypes) {
+        return (DefaultUpstreamBindingBuilder) super.consumes(consumeTypes);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder consumes(Iterable<MediaType> consumeTypes) {
+        return (DefaultUpstreamBindingBuilder) super.consumes(consumeTypes);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder produces(MediaType... produceTypes) {
+        return (DefaultUpstreamBindingBuilder) super.produces(produceTypes);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder produces(Iterable<MediaType> produceTypes) {
+        return (DefaultUpstreamBindingBuilder) super.produces(produceTypes);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder matchesParams(String... paramPredicates) {
+        return (DefaultUpstreamBindingBuilder) super.matchesParams(paramPredicates);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder matchesParams(Iterable<String> paramPredicates) {
+        return (DefaultUpstreamBindingBuilder) super.matchesParams(paramPredicates);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder matchesParams(String paramName,
+                                                       Predicate<? super String> valuePredicate) {
+        return (DefaultUpstreamBindingBuilder) super.matchesParams(paramName, valuePredicate);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder matchesHeaders(String... headerPredicates) {
+        return (DefaultUpstreamBindingBuilder) super.matchesHeaders(headerPredicates);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder matchesHeaders(Iterable<String> headerPredicates) {
+        return (DefaultUpstreamBindingBuilder) super.matchesHeaders(headerPredicates);
+    }
+
+    @Override
+    public DefaultUpstreamBindingBuilder matchesHeaders(CharSequence headerName,
+                                                        Predicate<? super String> valuePredicate) {
+        return (DefaultUpstreamBindingBuilder) super.matchesHeaders(headerName, valuePredicate);
+    }
+}

--- a/core/src/main/java/dev/gihwan/tollgate/core/Tollgate.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/Tollgate.java
@@ -40,8 +40,8 @@ public final class Tollgate {
 
     private static final Logger logger = LoggerFactory.getLogger(Tollgate.class);
 
-    public static TollgateBuilder builder() {
-        return new TollgateBuilder();
+    public static DefaultTollgateBuilder builder() {
+        return new DefaultTollgateBuilder();
     }
 
     private final Server server;

--- a/core/src/main/java/dev/gihwan/tollgate/core/TollgateBuilder.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/TollgateBuilder.java
@@ -26,13 +26,16 @@ package dev.gihwan.tollgate.core;
 
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceBindingBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 
-public final class TollgateBuilder {
+public abstract class TollgateBuilder {
 
     private final ServerBuilder serverBuilder = Server.builder();
 
-    TollgateBuilder() {}
+    protected TollgateBuilder() {}
+
+    public abstract UpstreamBindingBuilder<? extends TollgateBuilder> route();
 
     /**
      * @see ServerBuilder#http(int)
@@ -51,15 +54,15 @@ public final class TollgateBuilder {
         return this;
     }
 
-    public UpstreamBindingBuilder route() {
-        return new UpstreamBindingBuilder(this, serverBuilder.route());
-    }
-
     public TollgateBuilder upstream(String pathPattern, Upstream upstream) {
         return route().path(pathPattern).build(upstream);
     }
 
-    public Tollgate build() {
+    public final Tollgate build() {
         return new Tollgate(serverBuilder.build());
+    }
+
+    protected final ServiceBindingBuilder serverRoute() {
+        return serverBuilder.route();
     }
 }

--- a/core/src/main/java/dev/gihwan/tollgate/core/UpstreamBindingBuilder.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/UpstreamBindingBuilder.java
@@ -30,12 +30,12 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServiceBindingBuilder;
 
-public final class UpstreamBindingBuilder {
+public abstract class UpstreamBindingBuilder<T extends TollgateBuilder> {
 
-    private final TollgateBuilder tollgateBuilder;
+    private final T tollgateBuilder;
     private final ServiceBindingBuilder serviceBindingBuilder;
 
-    UpstreamBindingBuilder(TollgateBuilder tollgateBuilder, ServiceBindingBuilder serviceBindingBuilder) {
+    protected UpstreamBindingBuilder(T tollgateBuilder, ServiceBindingBuilder serviceBindingBuilder) {
         this.tollgateBuilder = tollgateBuilder;
         this.serviceBindingBuilder = serviceBindingBuilder;
     }
@@ -43,7 +43,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#path(String)
      */
-    public UpstreamBindingBuilder path(String pathPattern) {
+    public UpstreamBindingBuilder<T> path(String pathPattern) {
         serviceBindingBuilder.path(pathPattern);
         return this;
     }
@@ -51,7 +51,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#pathPrefix(String)
      */
-    public UpstreamBindingBuilder pathPrefix(String prefix) {
+    public UpstreamBindingBuilder<T> pathPrefix(String prefix) {
         serviceBindingBuilder.pathPrefix(prefix);
         return this;
     }
@@ -59,7 +59,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#methods(HttpMethod...)
      */
-    public UpstreamBindingBuilder methods(HttpMethod... methods) {
+    public UpstreamBindingBuilder<T> methods(HttpMethod... methods) {
         serviceBindingBuilder.methods(methods);
         return this;
     }
@@ -67,7 +67,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#methods(Iterable)
      */
-    public UpstreamBindingBuilder methods(Iterable<HttpMethod> methods) {
+    public UpstreamBindingBuilder<T> methods(Iterable<HttpMethod> methods) {
         serviceBindingBuilder.methods(methods);
         return this;
     }
@@ -75,7 +75,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#get(String)
      */
-    public UpstreamBindingBuilder get(String pathPattern) {
+    public UpstreamBindingBuilder<T> get(String pathPattern) {
         serviceBindingBuilder.get(pathPattern);
         return this;
     }
@@ -83,7 +83,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#post(String)
      */
-    public UpstreamBindingBuilder post(String pathPattern) {
+    public UpstreamBindingBuilder<T> post(String pathPattern) {
         serviceBindingBuilder.post(pathPattern);
         return this;
     }
@@ -91,7 +91,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#put(String)
      */
-    public UpstreamBindingBuilder put(String pathPattern) {
+    public UpstreamBindingBuilder<T> put(String pathPattern) {
         serviceBindingBuilder.put(pathPattern);
         return this;
     }
@@ -99,7 +99,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#patch(String)
      */
-    public UpstreamBindingBuilder patch(String pathPattern) {
+    public UpstreamBindingBuilder<T> patch(String pathPattern) {
         serviceBindingBuilder.patch(pathPattern);
         return this;
     }
@@ -107,7 +107,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#delete(String)
      */
-    public UpstreamBindingBuilder delete(String pathPattern) {
+    public UpstreamBindingBuilder<T> delete(String pathPattern) {
         serviceBindingBuilder.delete(pathPattern);
         return this;
     }
@@ -115,7 +115,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#options(String)
      */
-    public UpstreamBindingBuilder options(String pathPattern) {
+    public UpstreamBindingBuilder<T> options(String pathPattern) {
         serviceBindingBuilder.options(pathPattern);
         return this;
     }
@@ -123,7 +123,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#head(String)
      */
-    public UpstreamBindingBuilder head(String pathPattern) {
+    public UpstreamBindingBuilder<T> head(String pathPattern) {
         serviceBindingBuilder.head(pathPattern);
         return this;
     }
@@ -131,7 +131,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#trace(String)
      */
-    public UpstreamBindingBuilder trace(String pathPattern) {
+    public UpstreamBindingBuilder<T> trace(String pathPattern) {
         serviceBindingBuilder.trace(pathPattern);
         return this;
     }
@@ -139,7 +139,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#connect(String)
      */
-    public UpstreamBindingBuilder connect(String pathPattern) {
+    public UpstreamBindingBuilder<T> connect(String pathPattern) {
         serviceBindingBuilder.connect(pathPattern);
         return this;
     }
@@ -147,7 +147,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#consumes(MediaType...)
      */
-    public UpstreamBindingBuilder consumes(MediaType... consumeTypes) {
+    public UpstreamBindingBuilder<T> consumes(MediaType... consumeTypes) {
         serviceBindingBuilder.consumes(consumeTypes);
         return this;
     }
@@ -155,7 +155,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#consumes(Iterable)
      */
-    public UpstreamBindingBuilder consumes(Iterable<MediaType> consumeTypes) {
+    public UpstreamBindingBuilder<T> consumes(Iterable<MediaType> consumeTypes) {
         serviceBindingBuilder.consumes(consumeTypes);
         return this;
     }
@@ -163,7 +163,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#produces(MediaType...)
      */
-    public UpstreamBindingBuilder produces(MediaType... produceTypes) {
+    public UpstreamBindingBuilder<T> produces(MediaType... produceTypes) {
         serviceBindingBuilder.produces(produceTypes);
         return this;
     }
@@ -171,7 +171,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#produces(Iterable)
      */
-    public UpstreamBindingBuilder produces(Iterable<MediaType> produceTypes) {
+    public UpstreamBindingBuilder<T> produces(Iterable<MediaType> produceTypes) {
         serviceBindingBuilder.produces(produceTypes);
         return this;
     }
@@ -179,7 +179,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#matchesParams(String...)
      */
-    public UpstreamBindingBuilder matchesParams(String... paramPredicates) {
+    public UpstreamBindingBuilder<T> matchesParams(String... paramPredicates) {
         serviceBindingBuilder.matchesParams(paramPredicates);
         return this;
     }
@@ -187,7 +187,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#matchesParams(Iterable)
      */
-    public UpstreamBindingBuilder matchesParams(Iterable<String> paramPredicates) {
+    public UpstreamBindingBuilder<T> matchesParams(Iterable<String> paramPredicates) {
         serviceBindingBuilder.matchesParams(paramPredicates);
         return this;
     }
@@ -195,7 +195,8 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#matchesParams(String, Predicate)
      */
-    public UpstreamBindingBuilder matchesParams(String paramName, Predicate<? super String> valuePredicate) {
+    public UpstreamBindingBuilder<T> matchesParams(String paramName,
+                                                   Predicate<? super String> valuePredicate) {
         serviceBindingBuilder.matchesParams(paramName, valuePredicate);
         return this;
     }
@@ -203,7 +204,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#matchesHeaders(String...)
      */
-    public UpstreamBindingBuilder matchesHeaders(String... headerPredicates) {
+    public UpstreamBindingBuilder<T> matchesHeaders(String... headerPredicates) {
         serviceBindingBuilder.matchesHeaders(headerPredicates);
         return this;
     }
@@ -211,7 +212,7 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#matchesHeaders(Iterable)
      */
-    public UpstreamBindingBuilder matchesHeaders(Iterable<String> headerPredicates) {
+    public UpstreamBindingBuilder<T> matchesHeaders(Iterable<String> headerPredicates) {
         serviceBindingBuilder.matchesHeaders(headerPredicates);
         return this;
     }
@@ -219,13 +220,13 @@ public final class UpstreamBindingBuilder {
     /**
      * @see ServiceBindingBuilder#matchesHeaders(CharSequence, Predicate)
      */
-    public UpstreamBindingBuilder matchesHeaders(CharSequence headerName,
-                                                 Predicate<? super String> valuePredicate) {
+    public UpstreamBindingBuilder<T> matchesHeaders(CharSequence headerName,
+                                                    Predicate<? super String> valuePredicate) {
         serviceBindingBuilder.matchesHeaders(headerName, valuePredicate);
         return this;
     }
 
-    public TollgateBuilder build(Upstream upstream) {
+    public final T build(Upstream upstream) {
         serviceBindingBuilder.build(new UpstreamHttpService(upstream));
         return tollgateBuilder;
     }

--- a/examples/pokeapi/pokeapi-gateway/application.conf
+++ b/examples/pokeapi/pokeapi-gateway/application.conf
@@ -3,13 +3,13 @@ tollgate {
   healthCheckPath = "/health"
 }
 
-include required(file("/routing/berry.conf"))
-include required(file("/routing/contest.conf"))
-include required(file("/routing/encounter.conf"))
-include required(file("/routing/evolution.conf"))
-include required(file("/routing/game.conf"))
-include required(file("/routing/item.conf"))
-include required(file("/routing/location.conf"))
-include required(file("/routing/machine.conf"))
-include required(file("/routing/move.conf"))
-include required(file("/routing/pokemon.conf"))
+include required(file("routing/berry.conf"))
+include required(file("routing/contest.conf"))
+include required(file("routing/encounter.conf"))
+include required(file("routing/evolution.conf"))
+include required(file("routing/game.conf"))
+include required(file("routing/item.conf"))
+include required(file("routing/location.conf"))
+include required(file("routing/machine.conf"))
+include required(file("routing/move.conf"))
+include required(file("routing/pokemon.conf"))

--- a/examples/pokeapi/pokeapi-gateway/routing/berry.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/berry.conf
@@ -4,16 +4,19 @@ tollgate {
       method = "GET"
       path = "/api/v2/berry/{idOrName}"
       upstream = ${tollgate.upstreams.berry}
+      upstream.remapping.path = "/berry/{idOrName}"
     }
     getBerryFirmness {
       method = "GET"
       path = "/api/v2/berry-firmness/{idOrName}"
       upstream = ${tollgate.upstreams.berry}
+      upstream.remapping.path = "/berry-firmness/{idOrName}"
     }
     getBerryFlavor {
       method = "GET"
       path = "/api/v2/berry-flavor/{idOrName}"
       upstream = ${tollgate.upstreams.berry}
+      upstream.remapping.path = "/berry-flavor/{idOrName}"
     }
   }
   upstreams {

--- a/examples/pokeapi/pokeapi-gateway/routing/berry.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/berry.conf
@@ -3,41 +3,23 @@ tollgate {
     getBerry {
       method = "GET"
       path = "/api/v2/berry/{idOrName}"
-      upstream {
-        service = ${tollgate.services.berry}
-        endpoint {
-          method = "GET"
-          path = "/berry/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.berry}
     }
     getBerryFirmness {
       method = "GET"
       path = "/api/v2/berry-firmness/{idOrName}"
-      upstream {
-        service = ${tollgate.services.berry}
-        endpoint {
-          method = "GET"
-          path = "/berry-firmness/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.berry}
     }
     getBerryFlavor {
       method = "GET"
       path = "/api/v2/berry-flavor/{idOrName}"
-      upstream {
-        service = ${tollgate.services.berry}
-        endpoint {
-          method = "GET"
-          path = "/berry-flavor/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.berry}
     }
   }
-  services {
+  upstreams {
     berry {
       scheme = "http"
-      authorities = [
+      endpoints = [
         {
           host = "berry"
           port = 8080

--- a/examples/pokeapi/pokeapi-gateway/routing/contest.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/contest.conf
@@ -3,12 +3,12 @@ tollgate {
     getContestType {
       method = "GET"
       path = "/api/v2/contest-type/{idOrName}"
-      upstream = ${tollgate.upstreams.contest}
-    }
-  }
-  upstreams {
-    contest {
-      uri = "http://contest:8080"
+      upstream {
+        uri = "http://contest:8080"
+        remapping {
+          path = "/contest-type/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/contest.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/contest.conf
@@ -3,16 +3,10 @@ tollgate {
     getContestType {
       method = "GET"
       path = "/api/v2/contest-type/{idOrName}"
-      upstream {
-        service = ${tollgate.services.contest}
-        endpoint {
-          method = "GET"
-          path = "/contest-type/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.contest}
     }
   }
-  services {
+  upstreams {
     contest {
       uri = "http://contest:8080"
     }

--- a/examples/pokeapi/pokeapi-gateway/routing/encounter.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/encounter.conf
@@ -3,12 +3,12 @@ tollgate {
     getEncounterMethod {
       method = "GET"
       path = "/api/v2/encounter-method/{idOrName}"
-      upstream = ${tollgate.upstreams.encounter}
-    }
-  }
-  upstreams {
-    encounter {
-      uri = "http://encounter:8080"
+      upstream {
+        uri = "http://encounter:8080"
+        remapping {
+          path = "/encounter-method/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/encounter.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/encounter.conf
@@ -3,16 +3,10 @@ tollgate {
     getEncounterMethod {
       method = "GET"
       path = "/api/v2/encounter-method/{idOrName}"
-      upstream {
-        service = ${tollgate.services.encounter}
-        endpoint {
-          method = "GET"
-          path = "/encounter-method/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.encounter}
     }
   }
-  services {
+  upstreams {
     encounter {
       uri = "http://encounter:8080"
     }

--- a/examples/pokeapi/pokeapi-gateway/routing/evolution.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/evolution.conf
@@ -3,16 +3,10 @@ tollgate {
     getEvolutionChain {
       method = "GET"
       path = "/api/v2/evolution-chain/{idOrName}"
-      upstream {
-        service = ${tollgate.services.evolution}
-        endpoint {
-          method = "GET"
-          path = "/evolution-chain/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.evolution}
     }
   }
-  services {
+  upstreams {
     evolution {
       uri = "http://evolution:8080"
     }

--- a/examples/pokeapi/pokeapi-gateway/routing/evolution.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/evolution.conf
@@ -3,12 +3,12 @@ tollgate {
     getEvolutionChain {
       method = "GET"
       path = "/api/v2/evolution-chain/{idOrName}"
-      upstream = ${tollgate.upstreams.evolution}
-    }
-  }
-  upstreams {
-    evolution {
-      uri = "http://evolution:8080"
+      upstream {
+        uri = "http://evolution:8080"
+        remapping {
+          path = "/evolution-chain/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/game.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/game.conf
@@ -3,12 +3,12 @@ tollgate {
     getGeneration {
       method = "GET"
       path = "/api/v2/generation/{idOrName}"
-      upstream = ${tollgate.upstreams.game}
-    }
-  }
-  upstreams {
-    game {
-      uri = "http://game:8080"
+      upstream {
+        uri = "http://game:8080"
+        remapping {
+          path = "/generation/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/game.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/game.conf
@@ -3,16 +3,10 @@ tollgate {
     getGeneration {
       method = "GET"
       path = "/api/v2/generation/{idOrName}"
-      upstream {
-        service = ${tollgate.services.game}
-        endpoint {
-          method = "GET"
-          path = "/generation/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.game}
     }
   }
-  services {
+  upstreams {
     game {
       uri = "http://game:8080"
     }

--- a/examples/pokeapi/pokeapi-gateway/routing/item.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/item.conf
@@ -3,12 +3,12 @@ tollgate {
     getItem {
       method = "GET"
       path = "/api/v2/item/{idOrName}"
-      upstream = ${tollgate.upstreams.item}
-    }
-  }
-  upstreams {
-    item {
-      uri = "http://item:8080"
+      upstream {
+        uri = "http://item:8080"
+        remapping {
+          path = "/item/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/item.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/item.conf
@@ -3,16 +3,10 @@ tollgate {
     getItem {
       method = "GET"
       path = "/api/v2/item/{idOrName}"
-      upstream {
-        service = ${tollgate.services.item}
-        endpoint {
-          method = "GET"
-          path = "/item/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.item}
     }
   }
-  services {
+  upstreams {
     item {
       uri = "http://item:8080"
     }

--- a/examples/pokeapi/pokeapi-gateway/routing/location.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/location.conf
@@ -3,16 +3,10 @@ tollgate {
     getLocation {
       method = "GET"
       path = "/api/v2/location/{idOrName}"
-      upstream {
-        service = ${tollgate.services.location}
-        endpoint {
-          method = "GET"
-          path = "/location/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.location}
     }
   }
-  services {
+  upstreams {
     location {
       uri = "http://location:8080"
     }

--- a/examples/pokeapi/pokeapi-gateway/routing/location.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/location.conf
@@ -3,12 +3,12 @@ tollgate {
     getLocation {
       method = "GET"
       path = "/api/v2/location/{idOrName}"
-      upstream = ${tollgate.upstreams.location}
-    }
-  }
-  upstreams {
-    location {
-      uri = "http://location:8080"
+      upstream {
+        uri = "http://location:8080"
+        remapping {
+          path = "/location/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/machine.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/machine.conf
@@ -3,16 +3,10 @@ tollgate {
     getMachine {
       method = "GET"
       path = "/api/v2/machine/{idOrName}"
-      upstream {
-        service = ${tollgate.services.machine}
-        endpoint {
-          method = "GET"
-          path = "/machine/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.machine}
     }
   }
-  services {
+  upstreams {
     machine {
       uri = "http://machine:8080"
     }

--- a/examples/pokeapi/pokeapi-gateway/routing/machine.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/machine.conf
@@ -3,12 +3,12 @@ tollgate {
     getMachine {
       method = "GET"
       path = "/api/v2/machine/{idOrName}"
-      upstream = ${tollgate.upstreams.machine}
-    }
-  }
-  upstreams {
-    machine {
-      uri = "http://machine:8080"
+      upstream {
+        uri = "http://machine:8080"
+        remapping {
+          path = "/machine/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/move.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/move.conf
@@ -3,12 +3,12 @@ tollgate {
     getMove {
       method = "GET"
       path = "/api/v2/move/{idOrName}"
-      upstream = ${tollgate.upstreams.move}
-    }
-  }
-  upstreams {
-    move {
-      uri = "http://move:8080"
+      upstream {
+        uri = "http://move:8080"
+        remapping {
+          path = "/move/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/move.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/move.conf
@@ -3,16 +3,10 @@ tollgate {
     getMove {
       method = "GET"
       path = "/api/v2/move/{idOrName}"
-      upstream {
-        service = ${tollgate.services.move}
-        endpoint {
-          method = "GET"
-          path = "/move/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.move}
     }
   }
-  services {
+  upstreams {
     move {
       uri = "http://move:8080"
     }

--- a/examples/pokeapi/pokeapi-gateway/routing/pokemon.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/pokemon.conf
@@ -3,12 +3,12 @@ tollgate {
     getAbility {
       method = "GET"
       path = "/api/v2/ability/{idOrName}"
-      upstream = ${tollgate.upstreams.pokemon}
-    }
-  }
-  upstreams {
-    pokemon {
-      uri = "http://pokemon:8080"
+      upstream {
+        uri = "http://pokemon:8080"
+        remapping {
+          path = "/ability/{idOrName}"
+        }
+      }
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/pokemon.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/pokemon.conf
@@ -3,16 +3,10 @@ tollgate {
     getAbility {
       method = "GET"
       path = "/api/v2/ability/{idOrName}"
-      upstream {
-        service = ${tollgate.services.pokemon}
-        endpoint {
-          method = "GET"
-          path = "/ability/{idOrName}"
-        }
-      }
+      upstream = ${tollgate.upstreams.pokemon}
     }
   }
-  services {
+  upstreams {
     pokemon {
       uri = "http://pokemon:8080"
     }

--- a/hocon/build.gradle.kts
+++ b/hocon/build.gradle.kts
@@ -26,19 +26,15 @@ import dev.gihwan.tollgate.Dependency
 
 plugins {
     java
-    application
-    id("com.google.cloud.tools.jib")
+    id("java-library")
 }
 
 dependencies {
+    api(project(":core"))
     implementation(project(":util"))
-    implementation(project(":core"))
-    implementation(project(":hocon"))
 
-    implementation(Dependency.jsr305)
-    implementation(Dependency.slf4j)
-
-    runtimeOnly(Dependency.logback)
+    api(Dependency.config)
+    implementation(Dependency.guava)
 
     testImplementation(Dependency.junitApi)
     testImplementation(Dependency.assertj)
@@ -56,16 +52,4 @@ java {
 
 tasks.test {
     useJUnitPlatform()
-}
-
-jib {
-    from {
-        image = "openjdk:11-jre-slim"
-    }
-    to {
-        image = "ghkim3221/tollgate-standalone"
-    }
-    container {
-        ports = listOf("8080")
-    }
 }

--- a/hocon/build.gradle.kts
+++ b/hocon/build.gradle.kts
@@ -25,7 +25,6 @@
 import dev.gihwan.tollgate.Dependency
 
 plugins {
-    java
     id("java-library")
 }
 

--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconTollgateBuilder.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconTollgateBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.hocon;
+
+import static dev.gihwan.tollgate.hocon.HoconTollgateConfigurators.configureWithHoconConfig;
+import static java.util.Objects.requireNonNull;
+
+import com.typesafe.config.Config;
+
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+
+import dev.gihwan.tollgate.core.TollgateBuilder;
+import dev.gihwan.tollgate.core.Upstream;
+
+public final class HoconTollgateBuilder extends TollgateBuilder {
+
+    public static HoconTollgateBuilder of(Config config) {
+        return new HoconTollgateBuilder(requireNonNull(config, "config"));
+    }
+
+    HoconTollgateBuilder(Config config) {
+        super();
+        configureWithHoconConfig(this, config);
+    }
+
+    @Override
+    public HoconTollgateBuilder http(int port) {
+        return (HoconTollgateBuilder) super.http(port);
+    }
+
+    @Override
+    public HoconTollgateBuilder healthCheck(String healthCheckPath) {
+        return (HoconTollgateBuilder) super.healthCheck(healthCheckPath);
+    }
+
+    @Override
+    public HoconTollgateBuilder healthCheck(String healthCheckPath, HealthCheckService healthCheckService) {
+        return (HoconTollgateBuilder) super.healthCheck(healthCheckPath, healthCheckService);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder route() {
+        return new HoconUpstreamBindingBuilder(this, serverRoute());
+    }
+
+    @Override
+    public HoconTollgateBuilder upstream(String pathPattern, Upstream upstream) {
+        return (HoconTollgateBuilder) super.upstream(pathPattern, upstream);
+    }
+}

--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconTollgateConfigurators.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconTollgateConfigurators.java
@@ -1,0 +1,106 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.hocon;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigObject;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpMethod;
+
+import dev.gihwan.tollgate.core.Upstream;
+import dev.gihwan.tollgate.core.UpstreamBuilder;
+import dev.gihwan.tollgate.core.remapping.RemappingRule;
+
+final class HoconTollgateConfigurators {
+
+    static void configureWithHoconConfig(HoconTollgateBuilder builder, Config config) {
+        if (config.hasPath("tollgate.port")) {
+            builder.http(config.getInt("tollgate.port"));
+        }
+        if (config.hasPath("tollgate.healthCheckPath")) {
+            builder.healthCheck(config.getString("tollgate.healthCheckPath"));
+        }
+        if (config.hasPath("tollgate.routing")) {
+            final Set<String> routes = config.getObject("tollgate.routing").keySet();
+            routes.stream()
+                  .map(route -> config.getObject("tollgate.routing." + route))
+                  .map(ConfigObject::toConfig)
+                  .forEach(routeConfig -> configureWithHoconRouteConfig(builder, routeConfig));
+        }
+    }
+
+    private static void configureWithHoconRouteConfig(HoconTollgateBuilder builder, Config routeConfig) {
+        checkArgument(routeConfig.hasPath("method"), "Route config must have method.");
+        checkArgument(routeConfig.hasPath("path"), "Route config must have path.");
+        checkArgument(routeConfig.hasPath("upstream"), "Route config must have upstream.");
+
+        builder.route()
+               .methods(routeConfig.getEnum(HttpMethod.class, "method"))
+               .path(routeConfig.getString("path"))
+               .build(configureWithHoconUpstreamConfig(routeConfig.getObject("upstream").toConfig()));
+    }
+
+    private static Upstream configureWithHoconUpstreamConfig(Config upstreamConfig) {
+        final UpstreamBuilder builder;
+        if (upstreamConfig.hasPath("uri")) {
+            builder = Upstream.builder(upstreamConfig.getString("uri"));
+        } else {
+            checkArgument(upstreamConfig.hasPath("endpoints"),
+                          "Upstream config must have one of uri and endpoints.");
+            checkArgument(upstreamConfig.hasPath("scheme"),
+                          "Upstream config must have scheme when configure with endpoints.");
+
+            final List<Endpoint> endpoints = upstreamConfig.getObjectList("endpoints")
+                                                           .stream()
+                                                           .map(ConfigObject::toConfig)
+                                                           .map(config -> {
+                                                               final String host = config.getString("host");
+                                                               final int port = config.getInt("port");
+                                                               return Endpoint.of(host, port);
+                                                           })
+                                                           .collect(Collectors.toUnmodifiableList());
+            builder = Upstream.builder(upstreamConfig.getString("scheme"), EndpointGroup.of(endpoints));
+        }
+
+        if (upstreamConfig.hasPath("remapping")) {
+            final Config remappingConfig = upstreamConfig.getObject("remapping").toConfig();
+            if (remappingConfig.hasPath("path")) {
+                builder.remapping(RemappingRule.path(remappingConfig.getString("path")));
+            }
+        }
+
+        return builder.build();
+    }
+
+    private HoconTollgateConfigurators() {}
+}

--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconUpstreamBindingBuilder.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconUpstreamBindingBuilder.java
@@ -1,0 +1,158 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.hocon;
+
+import java.util.function.Predicate;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServiceBindingBuilder;
+
+import dev.gihwan.tollgate.core.UpstreamBindingBuilder;
+
+public final class HoconUpstreamBindingBuilder extends UpstreamBindingBuilder<HoconTollgateBuilder> {
+
+    HoconUpstreamBindingBuilder(HoconTollgateBuilder tollgateBuilder,
+                                ServiceBindingBuilder serviceBindingBuilder) {
+        super(tollgateBuilder, serviceBindingBuilder);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder path(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.path(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder pathPrefix(String prefix) {
+        return (HoconUpstreamBindingBuilder) super.pathPrefix(prefix);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder methods(HttpMethod... methods) {
+        return (HoconUpstreamBindingBuilder) super.methods(methods);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder methods(Iterable<HttpMethod> methods) {
+        return (HoconUpstreamBindingBuilder) super.methods(methods);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder get(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.get(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder post(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.post(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder put(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.put(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder patch(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.patch(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder delete(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.delete(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder options(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.options(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder head(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.head(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder trace(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.trace(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder connect(String pathPattern) {
+        return (HoconUpstreamBindingBuilder) super.connect(pathPattern);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder consumes(MediaType... consumeTypes) {
+        return (HoconUpstreamBindingBuilder) super.consumes(consumeTypes);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder consumes(Iterable<MediaType> consumeTypes) {
+        return (HoconUpstreamBindingBuilder) super.consumes(consumeTypes);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder produces(MediaType... produceTypes) {
+        return (HoconUpstreamBindingBuilder) super.produces(produceTypes);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder produces(Iterable<MediaType> produceTypes) {
+        return (HoconUpstreamBindingBuilder) super.produces(produceTypes);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder matchesParams(String... paramPredicates) {
+        return (HoconUpstreamBindingBuilder) super.matchesParams(paramPredicates);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder matchesParams(Iterable<String> paramPredicates) {
+        return (HoconUpstreamBindingBuilder) super.matchesParams(paramPredicates);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder matchesParams(String paramName,
+                                                     Predicate<? super String> valuePredicate) {
+        return (HoconUpstreamBindingBuilder) super.matchesParams(paramName, valuePredicate);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder matchesHeaders(String... headerPredicates) {
+        return (HoconUpstreamBindingBuilder) super.matchesHeaders(headerPredicates);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder matchesHeaders(Iterable<String> headerPredicates) {
+        return (HoconUpstreamBindingBuilder) super.matchesHeaders(headerPredicates);
+    }
+
+    @Override
+    public HoconUpstreamBindingBuilder matchesHeaders(CharSequence headerName,
+                                                      Predicate<? super String> valuePredicate) {
+        return (HoconUpstreamBindingBuilder) super.matchesHeaders(headerName, valuePredicate);
+    }
+}

--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/package-info.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/package-info.java
@@ -22,50 +22,7 @@
  * SOFTWARE.
  */
 
-import dev.gihwan.tollgate.Dependency
+@NonNullByDefault
+package dev.gihwan.tollgate.hocon;
 
-plugins {
-    java
-    application
-    id("com.google.cloud.tools.jib")
-}
-
-dependencies {
-    implementation(project(":util"))
-    implementation(project(":core"))
-    implementation(project(":hocon"))
-
-    implementation(Dependency.jsr305)
-    implementation(Dependency.slf4j)
-
-    runtimeOnly(Dependency.logback)
-
-    testImplementation(Dependency.junitApi)
-    testImplementation(Dependency.assertj)
-    testImplementation(Dependency.awaitility)
-    testImplementation(Dependency.mockito)
-    testImplementation(Dependency.armeriaJunit)
-
-    testRuntimeOnly(Dependency.junitEngine)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-jib {
-    from {
-        image = "openjdk:11-jre-slim"
-    }
-    to {
-        image = "ghkim3221/tollgate-standalone"
-    }
-    container {
-        ports = listOf("8080")
-    }
-}
+import dev.gihwan.tollgate.util.NonNullByDefault;

--- a/hocon/src/test/java/dev/gihwan/tollgate/hocon/HoconTollgateBuilderTest.java
+++ b/hocon/src/test/java/dev/gihwan/tollgate/hocon/HoconTollgateBuilderTest.java
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.hocon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import dev.gihwan.tollgate.core.Tollgate;
+
+class HoconTollgateBuilderTest {
+
+    @RegisterExtension
+    static final ServerExtension serviceServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/foo",
+                       (ctx, req) -> HttpResponse.from(req.aggregate().thenApply(aggregated -> {
+                           return HttpResponse.of("bar");
+                       })));
+        }
+    };
+
+    @Test
+    void build() {
+        final Config config =
+                ConfigFactory.load()
+                             .withValue("tollgate.routing.foo.upstream.uri",
+                                        ConfigValueFactory.fromAnyRef(serviceServer.httpUri().toString()));
+
+        final Tollgate tollgate = HoconTollgateBuilder.of(config).build();
+        try {
+            tollgate.start();
+            assertThat(tollgate.activeLocalPort()).isPositive();
+
+            final WebClient client = WebClient.of("http://127.0.0.1:" + tollgate.activeLocalPort());
+
+            AggregatedHttpResponse res = client.get("/health").aggregate().join();
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+
+            res = client.get("/foo").aggregate().join();
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+            assertThat(res.contentUtf8()).isEqualTo("bar");
+        } finally {
+            tollgate.stop();
+        }
+    }
+}

--- a/hocon/src/test/java/dev/gihwan/tollgate/hocon/HoconTollgateBuilderTest.java
+++ b/hocon/src/test/java/dev/gihwan/tollgate/hocon/HoconTollgateBuilderTest.java
@@ -48,10 +48,7 @@ class HoconTollgateBuilderTest {
     static final ServerExtension serviceServer = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            sb.service("/foo",
-                       (ctx, req) -> HttpResponse.from(req.aggregate().thenApply(aggregated -> {
-                           return HttpResponse.of("bar");
-                       })));
+            sb.service("/foo", (ctx, req) -> HttpResponse.of("bar"));
         }
     };
 

--- a/hocon/src/test/resources/application.conf
+++ b/hocon/src/test/resources/application.conf
@@ -1,0 +1,10 @@
+tollgate {
+  port = 0
+  healthCheckPath = "/health"
+  routing {
+    foo {
+      method = "GET"
+      path = "/foo"
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@
 rootProject.name = "tollgate"
 
 include("core")
+include("hocon")
 include("standalone")
 include("util")
 


### PR DESCRIPTION
### Motivation

#76

### Descriptions

 - Introduce `hocon` module
   - Move parsing HOCON file from `standalone` to `hocon` module.
 - Make `TollgateBuilder` and `UpstreamBindingBuilder` abstract and use `DefaultTollgateBuilder` and `DefaultUpstreamBindingBuilder` instead.

### Results

 - Close #76
 - Fix remapping path in `pokeapi` example.
