### PR TITLE
Introduce testing and junit5 module

### DIFF
--- a/junit5/build.gradle.kts
+++ b/junit5/build.gradle.kts
@@ -29,22 +29,14 @@ plugins {
 }
 
 dependencies {
+    api(project(":testing"))
+    api(Dependency.junitApi)
     implementation(project(":util"))
+    implementation(Dependency.armeriaJunit)
 
-    api(Dependency.armeria)
-    implementation(Dependency.commonsLang3)
-    implementation(Dependency.guava)
-    implementation(Dependency.jsr305)
-    implementation(Dependency.slf4j)
-
-    testImplementation(project(":junit5"))
     testImplementation(Dependency.assertj)
-    testImplementation(Dependency.awaitility)
-    testImplementation(Dependency.mockito)
-    testImplementation(Dependency.armeriaJunit)
 
     testRuntimeOnly(Dependency.junitEngine)
-    testRuntimeOnly(Dependency.logback)
 }
 
 java {

--- a/junit5/src/main/java/dev/gihwan/tollgate/junit5/TollgateExtension.java
+++ b/junit5/src/main/java/dev/gihwan/tollgate/junit5/TollgateExtension.java
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.junit5;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.common.AbstractAllOrEachExtension;
+
+import dev.gihwan.tollgate.core.Tollgate;
+import dev.gihwan.tollgate.core.TollgateBuilder;
+import dev.gihwan.tollgate.testing.TestingTollgate;
+
+/**
+ * An {@link Extension} which starts and stops the {@link Tollgate} following test lifecycle.
+ */
+public abstract class TollgateExtension extends AbstractAllOrEachExtension {
+
+    private final TestingTollgate delegate;
+
+    protected TollgateExtension() {
+        delegate = TestingTollgate.of(TollgateExtension.this::configure);
+    }
+
+    /**
+     * Configures the {@link Tollgate} with the specified {@link TollgateBuilder}.
+     */
+    protected abstract void configure(TollgateBuilder builder);
+
+    @Override
+    public final void before(ExtensionContext context) throws Exception {
+        delegate.start();
+    }
+
+    @Override
+    public final void after(ExtensionContext context) throws Exception {
+        delegate.stop();
+    }
+
+    /**
+     * @see TestingTollgate#httpPort()
+     */
+    public int httpPort() {
+        return delegate.httpPort();
+    }
+
+    /**
+     * @see TestingTollgate#port(SessionProtocol)
+     */
+    public int port(SessionProtocol protocol) {
+        return delegate.port(protocol);
+    }
+
+    /**
+     * @see TestingTollgate#httpUri()
+     */
+    public URI httpUri() {
+        return delegate.httpUri();
+    }
+}

--- a/junit5/src/main/java/dev/gihwan/tollgate/junit5/package-info.java
+++ b/junit5/src/main/java/dev/gihwan/tollgate/junit5/package-info.java
@@ -22,36 +22,7 @@
  * SOFTWARE.
  */
 
-import dev.gihwan.tollgate.Dependency
+@NonNullByDefault
+package dev.gihwan.tollgate.junit5;
 
-plugins {
-    id("java-library")
-}
-
-dependencies {
-    implementation(project(":util"))
-
-    api(Dependency.armeria)
-    implementation(Dependency.commonsLang3)
-    implementation(Dependency.guava)
-    implementation(Dependency.jsr305)
-    implementation(Dependency.slf4j)
-
-    testImplementation(project(":junit5"))
-    testImplementation(Dependency.assertj)
-    testImplementation(Dependency.awaitility)
-    testImplementation(Dependency.mockito)
-    testImplementation(Dependency.armeriaJunit)
-
-    testRuntimeOnly(Dependency.junitEngine)
-    testRuntimeOnly(Dependency.logback)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-tasks.test {
-    useJUnitPlatform()
-}
+import dev.gihwan.tollgate.util.NonNullByDefault;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Gihwan Kim
+ * Copyright (c) 2020 - 2021 Gihwan Kim
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,9 @@ rootProject.name = "tollgate"
 
 include("core")
 include("hocon")
+include("junit5")
 include("standalone")
+include("testing")
 include("util")
 
 include(":examples:helloworld")

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -29,22 +29,15 @@ plugins {
 }
 
 dependencies {
+    api(project(":core"))
+    api(Dependency.jsr305)
     implementation(project(":util"))
-
-    api(Dependency.armeria)
-    implementation(Dependency.commonsLang3)
     implementation(Dependency.guava)
-    implementation(Dependency.jsr305)
-    implementation(Dependency.slf4j)
 
-    testImplementation(project(":junit5"))
+    testImplementation(Dependency.junitApi)
     testImplementation(Dependency.assertj)
-    testImplementation(Dependency.awaitility)
-    testImplementation(Dependency.mockito)
-    testImplementation(Dependency.armeriaJunit)
 
     testRuntimeOnly(Dependency.junitEngine)
-    testRuntimeOnly(Dependency.logback)
 }
 
 java {

--- a/testing/src/main/java/dev/gihwan/tollgate/testing/TestingTollgate.java
+++ b/testing/src/main/java/dev/gihwan/tollgate/testing/TestingTollgate.java
@@ -1,0 +1,130 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.testing;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.util.function.Consumer;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+import dev.gihwan.tollgate.core.DefaultTollgateBuilder;
+import dev.gihwan.tollgate.core.Tollgate;
+import dev.gihwan.tollgate.core.TollgateBuilder;
+
+/**
+ * A delegate of {@link Tollgate} which provides features for testing.
+ */
+public abstract class TestingTollgate implements SafeCloseable {
+
+    /**
+     * Creates and starts a new {@link Tollgate} which configured with the given {@code builderConsumer}.
+     * Please note that the returned {@link Tollgate} is already started automatically.
+     */
+    @CheckReturnValue
+    public static TestingTollgate withTestingTollgate(Consumer<? super TollgateBuilder> builderConsumer) {
+        final TestingTollgate tollgate = of(builderConsumer);
+        tollgate.start();
+        return tollgate;
+    }
+
+    /**
+     * Creates a new {@link Tollgate} which configured with the given {@code builderConsumer}.
+     */
+    public static TestingTollgate of(Consumer<? super TollgateBuilder> builderConsumer) {
+        requireNonNull(builderConsumer, "builderConsumer");
+        return new TestingTollgate() {
+            @Override
+            protected void configure(TollgateBuilder builder) {
+                builderConsumer.accept(builder);
+            }
+        };
+    }
+
+    @Nullable
+    private Tollgate delegate;
+
+    TestingTollgate() {}
+
+    /**
+     * Configures the {@link Tollgate} with the specified {@link TollgateBuilder}.
+     */
+    protected abstract void configure(TollgateBuilder builder);
+
+    /**
+     * Starts the {@link Tollgate}.
+     */
+    public void start() {
+        final DefaultTollgateBuilder builder = Tollgate.builder();
+        configure(builder);
+
+        delegate = builder.build();
+        delegate.start();
+    }
+
+    /**
+     * Stops the {@link Tollgate}.
+     */
+    public void stop() {
+        checkState(delegate != null, "Tollgate did not start.");
+        delegate.stop();
+    }
+
+    /**
+     * @see TestingTollgate#stop()
+     */
+    @Override
+    public void close() {
+        stop();
+    }
+
+    /**
+     * Returns the local port which the {@link Tollgate} serves HTTP.
+     */
+    public int httpPort() {
+        return port(SessionProtocol.HTTP);
+    }
+
+    /**
+     * Returns the local port which the {@link Tollgate} serves the given {@code protocol}.
+     */
+    public int port(SessionProtocol protocol) {
+        checkState(delegate != null, "Tollgate did not start.");
+        return delegate.activeLocalPort(protocol);
+    }
+
+    /**
+     * Returns the {@link URI} which the {@link Tollgate} serves HTTP.
+     */
+    public URI httpUri() {
+        return URI.create("http://127.0.0.1:" + httpPort());
+    }
+}

--- a/testing/src/main/java/dev/gihwan/tollgate/testing/package-info.java
+++ b/testing/src/main/java/dev/gihwan/tollgate/testing/package-info.java
@@ -22,36 +22,7 @@
  * SOFTWARE.
  */
 
-import dev.gihwan.tollgate.Dependency
+@NonNullByDefault
+package dev.gihwan.tollgate.testing;
 
-plugins {
-    id("java-library")
-}
-
-dependencies {
-    implementation(project(":util"))
-
-    api(Dependency.armeria)
-    implementation(Dependency.commonsLang3)
-    implementation(Dependency.guava)
-    implementation(Dependency.jsr305)
-    implementation(Dependency.slf4j)
-
-    testImplementation(project(":junit5"))
-    testImplementation(Dependency.assertj)
-    testImplementation(Dependency.awaitility)
-    testImplementation(Dependency.mockito)
-    testImplementation(Dependency.armeriaJunit)
-
-    testRuntimeOnly(Dependency.junitEngine)
-    testRuntimeOnly(Dependency.logback)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-tasks.test {
-    useJUnitPlatform()
-}
+import dev.gihwan.tollgate.util.NonNullByDefault;

--- a/testing/src/test/java/dev/gihwan/tollgate/testing/TestingTollgateTest.java
+++ b/testing/src/test/java/dev/gihwan/tollgate/testing/TestingTollgateTest.java
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.testing;
+
+import static dev.gihwan.tollgate.testing.TestingTollgate.withTestingTollgate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+
+import dev.gihwan.tollgate.core.Upstream;
+
+class TestingTollgateTest {
+
+    @Test
+    void port() {
+        try (TestingTollgate tollgate = withTestingTollgate(builder -> {
+            builder.upstream("/foo", Upstream.of("http://127.0.0.1"));
+        })) {
+            assertThat(tollgate.httpPort()).isPositive();
+        }
+    }
+
+    @Test
+    void uri() {
+        try (TestingTollgate tollgate = withTestingTollgate(builder -> {
+            builder.upstream("/foo", Upstream.of("http://127.0.0.1"));
+        })) {
+            assertThat(tollgate.httpUri()).isNotNull();
+        }
+    }
+
+    @Test
+    void healthCheck() {
+        try (TestingTollgate tollgate = withTestingTollgate(builder -> {
+            builder.healthCheck("/health");
+        })) {
+            final WebClient webClient = WebClient.of(tollgate.httpUri());
+            final AggregatedHttpResponse res = webClient.get("/health").aggregate().join();
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

#84

### Description

 - Introduce `testing` module
    - Add `TestingTollgate` which is a delegate of the `Tollgate` that which provides features for testing.
 - Introduce `junit5` module
    - Add `TollgateExtension` which is a `Extension` that starts and stops the `Tollgate` following test lifecycle.

### Results

 - Close #84
 - Users can use `TestingTollgate` in a unit test method by calling `withTestingTollgate`:
   ```java
   try (TestingTollgate tollgate = withTestingTollgate(builder -> {
      // configure with the given builder
   })) {
      // do test
   }
   ```
 - Users can use `TollgateExtension` with `@RegisterExtension`:
   ```java
   @RegisterExtension
   static final TollgateExtension tollgate = new TollgateExtension() {
       @Override
       protected void configure(TollgateBuilder builder) {
           // configure with the given builder
       }
   };
   ```
 - Migrate existing tests to use `withTestingTollgate` and `TollgateExtension`.
