### PR TITLE
Fix `Upstream#decorate` signature

### DIFF
--- a/core/src/main/java/dev/gihwan/tollgate/core/Upstream.java
+++ b/core/src/main/java/dev/gihwan/tollgate/core/Upstream.java
@@ -83,8 +83,7 @@ public interface Upstream extends Service<HttpRequest, HttpResponse> {
     @CheckReturnValue
     HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception;
 
-    default <T extends Service<Req, Res>, Req extends HttpRequest, Res extends HttpResponse> T decorate(
-            Function<? super Upstream, T> decorator) {
+    default <T extends Upstream> T decorate(Function<? super Upstream, T> decorator) {
         final T newUpstream = decorator.apply(this);
 
         if (newUpstream == null) {


### PR DESCRIPTION
### Motivation

`Upstream#decorate` has wrong signature.

### Description

Change `T extends Service<Req, Res>, Req extends HttpRequest, Res extends HttpResponse` to `T extends Upstream`.

### Result

Only `Upstream`s can be decorated.
