### PR TITLE
Introduce remapping module

### DIFF
--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/DecoratingUpstream.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/DecoratingUpstream.java
@@ -24,21 +24,14 @@
 
 package dev.gihwan.tollgate.gateway;
 
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
 
-final class UpstreamHttpService implements HttpService {
+/**
+ * A {@link Upstream} which decorates another {@link Upstream}.
+ */
+public abstract class DecoratingUpstream extends AbstractUnwrappable<Upstream> implements Upstream {
 
-    private final Upstream upstream;
-
-    UpstreamHttpService(Upstream upstream) {
-        this.upstream = upstream;
-    }
-
-    @Override
-    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        return upstream.forward(ctx, req);
+    protected DecoratingUpstream(Upstream delegate) {
+        super(delegate);
     }
 }

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBuilder.java
@@ -31,21 +31,15 @@ import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.ImmutableList;
-
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.SessionProtocol;
 
-import dev.gihwan.tollgate.gateway.remapping.RemappingRule;
-
 public final class UpstreamBuilder {
 
     @Nullable
     private Function<? super Upstream, ? extends Upstream> decorator;
-    @Nullable
-    private RemappingRule remappingRule;
 
     private final WebClientBuilder clientBuilder;
 
@@ -61,19 +55,6 @@ public final class UpstreamBuilder {
         clientBuilder = WebClient.builder(protocol, endpointGroup, path);
     }
 
-    public UpstreamBuilder remapping(RemappingRule... remappingRules) {
-        return remapping(ImmutableList.copyOf(requireNonNull(remappingRules, "remappingRules")));
-    }
-
-    public UpstreamBuilder remapping(Iterable<? extends RemappingRule> remappingRules) {
-        if (remappingRule == null) {
-            remappingRule = RemappingRule.of(remappingRules);
-        } else {
-            remappingRule = remappingRule.andThen(RemappingRule.of(remappingRules));
-        }
-        return this;
-    }
-
     public UpstreamBuilder decorator(Function<? super Upstream, ? extends Upstream> decorator) {
         requireNonNull(decorator, "decorator");
         if (this.decorator == null) {
@@ -85,7 +66,7 @@ public final class UpstreamBuilder {
     }
 
     public Upstream build() {
-        Upstream upstream = new DefaultUpstream(clientBuilder.build(), remappingRule);
+        Upstream upstream = new DefaultUpstream(clientBuilder.build());
         if (decorator != null) {
             upstream = upstream.decorate(decorator);
         }

--- a/hocon/build.gradle.kts
+++ b/hocon/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
 dependencies {
     api(project(":gateway"))
     implementation(project(":util"))
+    implementation(project(":remapping"))
 
     api(Dependency.config)
     implementation(Dependency.guava)

--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconTollgateConfigurators.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconTollgateConfigurators.java
@@ -40,7 +40,8 @@ import com.linecorp.armeria.common.HttpMethod;
 import dev.gihwan.tollgate.gateway.GatewayBuilder;
 import dev.gihwan.tollgate.gateway.Upstream;
 import dev.gihwan.tollgate.gateway.UpstreamBuilder;
-import dev.gihwan.tollgate.gateway.remapping.RemappingRule;
+import dev.gihwan.tollgate.remapping.RemappingRequestUpstream;
+import dev.gihwan.tollgate.remapping.RemappingRequestUpstreamBuilder;
 
 final class HoconTollgateConfigurators {
 
@@ -95,9 +96,11 @@ final class HoconTollgateConfigurators {
 
         if (upstreamConfig.hasPath("remapping")) {
             final Config remappingConfig = upstreamConfig.getObject("remapping").toConfig();
+            final RemappingRequestUpstreamBuilder remappingBuilder = RemappingRequestUpstream.builder();
             if (remappingConfig.hasPath("path")) {
-                builder.remapping(RemappingRule.path(remappingConfig.getString("path")));
+                remappingBuilder.path(remappingConfig.getString("path"));
             }
+            builder.decorator(remappingBuilder.newDecorator());
         }
 
         return builder.build();

--- a/remapping/build.gradle.kts
+++ b/remapping/build.gradle.kts
@@ -22,23 +22,31 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.gateway;
+import dev.gihwan.tollgate.Dependency
 
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.ServiceRequestContext;
+plugins {
+    id("java-library")
+}
 
-final class UpstreamHttpService implements HttpService {
+dependencies {
+    implementation(project(":util"))
+    implementation(project(":gateway"))
 
-    private final Upstream upstream;
+    implementation(Dependency.guava)
+    implementation(Dependency.slf4j)
 
-    UpstreamHttpService(Upstream upstream) {
-        this.upstream = upstream;
-    }
+    testImplementation(project(":junit5"))
+    testImplementation(Dependency.assertj)
+    implementation(Dependency.armeriaJunit)
 
-    @Override
-    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        return upstream.forward(ctx, req);
-    }
+    testRuntimeOnly(Dependency.junitEngine)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingRequestPathStrategy.java
+++ b/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingRequestPathStrategy.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.gateway.remapping;
+package dev.gihwan.tollgate.remapping;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,14 +33,14 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-final class RemappingPathRule implements RemappingRule {
+class RemappingRequestPathStrategy implements RemappingRequestStrategy {
 
     private static final String PATH_SEPARATOR = "/";
     private static final Splitter PATH_SPLITTER = Splitter.on(PATH_SEPARATOR);
 
     private final String pathPattern;
 
-    RemappingPathRule(String pathPattern) {
+    RemappingRequestPathStrategy(String pathPattern) {
         this.pathPattern = pathPattern;
     }
 

--- a/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingRequestUpstreamBuilder.java
+++ b/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingRequestUpstreamBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.remapping;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpRequest;
+
+import dev.gihwan.tollgate.gateway.Upstream;
+
+/**
+ * A builder for {@link RemappingRequestUpstream}.
+ */
+public final class RemappingRequestUpstreamBuilder {
+
+    @Nullable
+    private RemappingRequestStrategy strategy;
+
+    RemappingRequestUpstreamBuilder() {}
+
+    /**
+     * Adds a new {@link RemappingRequestStrategy} that remaps {@link HttpRequest} path with the given
+     * {@code pathPattern}.
+     *
+     * @see RemappingRequestPathStrategy#path(String)
+     * @see RemappingRequestUpstreamBuilder#strategy(RemappingRequestStrategy)
+     */
+    public RemappingRequestUpstreamBuilder path(String pathPattern) {
+        return strategy(RemappingRequestStrategy.path(pathPattern));
+    }
+
+    /**
+     * Adds the given {@link RemappingRequestStrategy}.
+     */
+    public RemappingRequestUpstreamBuilder strategy(RemappingRequestStrategy strategy) {
+        requireNonNull(strategy, "strategy");
+        if (this.strategy == null) {
+            this.strategy = strategy;
+        } else {
+            this.strategy = this.strategy.andThen(strategy);
+        }
+        return this;
+    }
+
+    /**
+     * Builds a new {@link RemappingRequestUpstream} decorator based on the properties of this builder.
+     */
+    public Function<? super Upstream, RemappingRequestUpstream> newDecorator() {
+        return this::build;
+    }
+
+    /**
+     * Builds a new {@link RemappingRequestUpstream} based on the properties of this builder.
+     */
+    public RemappingRequestUpstream build(Upstream delegate) {
+        checkState(strategy != null, "Must set at lease one remapping strategy");
+        return new RemappingRequestUpstream(delegate, strategy);
+    }
+}

--- a/remapping/src/main/java/dev/gihwan/tollgate/remapping/package-info.java
+++ b/remapping/src/main/java/dev/gihwan/tollgate/remapping/package-info.java
@@ -23,6 +23,6 @@
  */
 
 @NonNullByDefault
-package dev.gihwan.tollgate.gateway.remapping;
+package dev.gihwan.tollgate.remapping;
 
 import dev.gihwan.tollgate.util.NonNullByDefault;

--- a/remapping/src/test/java/dev/gihwan/tollgate/remapping/RemappingRequestPathStrategyTest.java
+++ b/remapping/src/test/java/dev/gihwan/tollgate/remapping/RemappingRequestPathStrategyTest.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package dev.gihwan.tollgate.gateway.remapping;
+package dev.gihwan.tollgate.remapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,33 +33,33 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.server.RoutingResult;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-class RemappingPathRuleTest {
+class RemappingRequestPathStrategyTest {
 
     @Test
-    void remappingPath() {
-        final RemappingPathRule rule = new RemappingPathRule("/foo/bar");
+    void remapPath() {
+        final RemappingRequestPathStrategy strategy = new RemappingRequestPathStrategy("/foo/bar");
 
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/baz/qux/quux");
         final ServiceRequestContext ctx = ServiceRequestContext.of(req);
 
-        final HttpRequest remappedReq = rule.remap(ctx, req);
+        final HttpRequest remappedReq = strategy.remap(ctx, req);
         assertThat(remappedReq.path()).isEqualTo("/foo/bar");
     }
 
     @Test
-    void remappingPathParam() {
-        final RemappingPathRule rule = new RemappingPathRule("/foo/{bar}");
+    void remapPathParam() {
+        final RemappingRequestPathStrategy strategy = new RemappingRequestPathStrategy("/foo/{bar}");
 
-        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/foo/baz/qux");
+        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/baz/qux/quux");
         final ServiceRequestContext ctx =
                 ServiceRequestContext.builder(req)
                                      .routingResult(RoutingResult.builder()
                                                                  .path(req.path())
-                                                                 .decodedParam("bar", "qux")
+                                                                 .decodedParam("bar", "quux")
                                                                  .build())
                                      .build();
 
-        final HttpRequest remappedReq = rule.remap(ctx, req);
-        assertThat(remappedReq.path()).isEqualTo("/foo/qux");
+        final HttpRequest remappedReq = strategy.remap(ctx, req);
+        assertThat(remappedReq.path()).isEqualTo("/foo/quux");
     }
 }

--- a/remapping/src/test/java/dev/gihwan/tollgate/remapping/RemappingRequestUpstreamTest.java
+++ b/remapping/src/test/java/dev/gihwan/tollgate/remapping/RemappingRequestUpstreamTest.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.remapping;
+
+import static dev.gihwan.tollgate.testing.TestGateway.withTestGateway;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import dev.gihwan.tollgate.gateway.Upstream;
+import dev.gihwan.tollgate.testing.TestGateway;
+
+class RemappingRequestUpstreamTest {
+
+    @RegisterExtension
+    static final ServerExtension serviceServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/foo", (ctx, req) -> HttpResponse.of("Hello, World!"));
+        }
+    };
+
+    @Test
+    void remapPath() {
+        try (TestGateway gateway = withTestGateway(builder -> {
+            builder.upstream("/bar", Upstream.builder(serviceServer.httpUri())
+                                             .decorator(RemappingRequestUpstream.builder()
+                                                                                .path("/foo")
+                                                                                .newDecorator())
+                                             .build());
+        })) {
+            final WebClient client = WebClient.of(gateway.httpUri());
+
+            AggregatedHttpResponse res = client.get("/bar").aggregate().join();
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+            assertThat(res.contentUtf8()).isEqualTo("Hello, World!");
+
+            res = client.get("/foo").aggregate().join();
+            assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ include("gateway")
 
 include("hocon")
 include("junit5")
+include("remapping")
 include("standalone")
 include("testing")
 include("util")


### PR DESCRIPTION
### Motivation

To provide remapping feature as an extension.

### Description

Introduce `remapping` module. At first, it supports only remapping `HttpRequest`. `RemappingRequestUpstream` can consist of various `RemappingRequestStrategy`.

### Result

 - `RemappingRule` is deleted.
 - User should add `remapping` module if wants to remap requests.
