### PR TITLE
Enable to customize building gateway from HOCON

### DIFF
--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconGatewayBuilder.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconGatewayBuilder.java
@@ -24,7 +24,6 @@
 
 package dev.gihwan.tollgate.hocon;
 
-import static dev.gihwan.tollgate.hocon.HoconTollgateConfigurators.configureWithHoconConfig;
 import static java.util.Objects.requireNonNull;
 
 import com.typesafe.config.Config;
@@ -32,15 +31,27 @@ import com.typesafe.config.Config;
 import dev.gihwan.tollgate.gateway.Gateway;
 import dev.gihwan.tollgate.gateway.GatewayBuilder;
 
+/**
+ * A builder for {@link Gateway} using a {@link Config}.
+ */
 public final class HoconGatewayBuilder {
 
+    /**
+     * Returns a new {@link HoconGatewayBuilder}.
+     */
     public static HoconGatewayBuilder of() {
         return new HoconGatewayBuilder(Gateway.builder());
     }
 
+    /**
+     * Returns a new {@link HoconGatewayBuilder} which builds a {@link Gateway} from the given
+     * {@link GatewayBuilder}.
+     */
     public static HoconGatewayBuilder of(GatewayBuilder delegate) {
         return new HoconGatewayBuilder(requireNonNull(delegate, "delegate"));
     }
+
+    private HoconGatewayConfigurator gatewayConfigurator = HoconGatewayConfigurator.ofDefault();
 
     private final GatewayBuilder delegate;
 
@@ -48,8 +59,20 @@ public final class HoconGatewayBuilder {
         this.delegate = delegate;
     }
 
+    /**
+     * Sets the {@link HoconGatewayConfigurator} which customizes how to build a {@link Gateway} using the
+     * specified {@link Config}. {@link HoconGatewayConfigurator#ofDefault()} is used by default.
+     */
+    public HoconGatewayBuilder gatewayConfigurator(HoconGatewayConfigurator gatewayConfigurator) {
+        this.gatewayConfigurator = requireNonNull(gatewayConfigurator, "gatewayConfigurator");
+        return this;
+    }
+
+    /**
+     * Returns a new {@link Gateway} using the given {@link Config} based on the properties of this builder.
+     */
     public Gateway build(Config config) {
-        configureWithHoconConfig(delegate, requireNonNull(config, "config"));
+        gatewayConfigurator.configure(delegate, requireNonNull(config, "config"));
         return delegate.build();
     }
 }

--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconGatewayConfigurator.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/HoconGatewayConfigurator.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.hocon;
+
+import com.typesafe.config.Config;
+
+import dev.gihwan.tollgate.gateway.Gateway;
+import dev.gihwan.tollgate.gateway.GatewayBuilder;
+
+/**
+ * A {@link FunctionalInterface} for configuring a {@link Gateway} using a {@link Config}.
+ */
+@FunctionalInterface
+public interface HoconGatewayConfigurator {
+
+    /**
+     * Returns the default implementation of {@link HoconGatewayConfigurator}.
+     */
+    static HoconGatewayConfigurator ofDefault() {
+        return DefaultHoconGatewayConfigurator.INSTANCE;
+    }
+
+    /**
+     * Configures a {@link Gateway} using the given {@link Config}.
+     */
+    void configure(GatewayBuilder builder, Config config);
+}


### PR DESCRIPTION
### Motivation

To customize how to build a `Gateway` using the HOCON config.

### Description

Add `HoconGatewayConfigurator` which enables to customize building `Gateway` from the given HOCON config. And add the default implementation of the `HoconGatewayConfigurator`.

Add missing javadoc.

### Result

Users can customize the way to build a `Gateway` using the HOCON config:
```java
HoconGatewayBuilder.of()
                   .gatewayConfigurator((builder, config) -> ... )
                   .build();
```
