### PR TITLE
Check argument instead of state when build in builder

### DIFF
--- a/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingRequestUpstreamBuilder.java
+++ b/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingRequestUpstreamBuilder.java
@@ -24,6 +24,7 @@
 
 package dev.gihwan.tollgate.remapping;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -80,7 +81,7 @@ public final class RemappingRequestUpstreamBuilder {
      * Builds a new {@link RemappingRequestUpstream} based on the properties of this builder.
      */
     public RemappingRequestUpstream build(Upstream delegate) {
-        checkState(strategy != null, "Must set at lease one remapping strategy");
+        checkArgument(strategy != null, "Must set at lease one remapping strategy");
         return new RemappingRequestUpstream(delegate, strategy);
     }
 }

--- a/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingRequestUpstreamBuilder.java
+++ b/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingRequestUpstreamBuilder.java
@@ -25,7 +25,6 @@
 package dev.gihwan.tollgate.remapping;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;


### PR DESCRIPTION
### Motivation

`IllegalArgumentException` is more clear when property of builder is wrong.

### Description

Change `checkState` to `checkArgument` in `RemappingRequestUpstreamBuilder#build()`.

### Result

`RemappingRequestUpstreamBuilder#build()` will throw `IllegalArgumentException` if property of the builder is wrong.
