### PR TITLE
Enable remapping both request and response in one decorator

### DIFF
--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/DefaultHoconGatewayConfigurator.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/DefaultHoconGatewayConfigurator.java
@@ -40,8 +40,8 @@ import com.linecorp.armeria.common.HttpMethod;
 import dev.gihwan.tollgate.gateway.GatewayBuilder;
 import dev.gihwan.tollgate.gateway.Upstream;
 import dev.gihwan.tollgate.gateway.UpstreamBuilder;
-import dev.gihwan.tollgate.remapping.RemappingRequestUpstream;
-import dev.gihwan.tollgate.remapping.RemappingRequestUpstreamBuilder;
+import dev.gihwan.tollgate.remapping.RemappingUpstream;
+import dev.gihwan.tollgate.remapping.RemappingUpstreamBuilder;
 
 enum DefaultHoconGatewayConfigurator implements HoconGatewayConfigurator {
 
@@ -99,9 +99,9 @@ enum DefaultHoconGatewayConfigurator implements HoconGatewayConfigurator {
 
         if (upstreamConfig.hasPath("remapping")) {
             final Config remappingConfig = upstreamConfig.getObject("remapping").toConfig();
-            final RemappingRequestUpstreamBuilder remappingBuilder = RemappingRequestUpstream.builder();
+            final RemappingUpstreamBuilder remappingBuilder = RemappingUpstream.builder();
             if (remappingConfig.hasPath("path")) {
-                remappingBuilder.path(remappingConfig.getString("path"));
+                remappingBuilder.requestPath(remappingConfig.getString("path"));
             }
             builder.decorator(remappingBuilder.newDecorator());
         }

--- a/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingUpstream.java
+++ b/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingUpstream.java
@@ -1,0 +1,112 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.remapping;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import dev.gihwan.tollgate.gateway.DecoratingUpstream;
+import dev.gihwan.tollgate.gateway.Upstream;
+
+/**
+ * A {@link Upstream} decorator for remapping {@link HttpRequest}s.
+ */
+public final class RemappingUpstream extends DecoratingUpstream {
+
+    /**
+     * Returns a new {@link Upstream} decorator which remaps {@link HttpRequest} using the given
+     * {@link RemappingRequestStrategy}.
+     */
+    public static Function<? super Upstream, RemappingUpstream> newDecorator(
+            RemappingRequestStrategy requestStrategy) {
+        return builder().requestStrategy(requireNonNull(requestStrategy, "requestStrategy")).newDecorator();
+    }
+
+    /**
+     * Returns a new {@link Upstream} decorator which remaps {@link HttpResponse} using the given
+     * {@link RemappingResponseStrategy}.
+     */
+    public static Function<? super Upstream, RemappingUpstream> newDecorator(
+            RemappingResponseStrategy responseStrategy) {
+        return builder().responseStrategy(requireNonNull(responseStrategy, "responseStrategy")).newDecorator();
+    }
+
+    /**
+     * Returns a new {@link Upstream} decorator which remaps {@link HttpRequest} and {@link HttpResponse} using
+     * the given {@link RemappingRequestStrategy} and {@link RemappingResponseStrategy} respectively.
+     */
+    public static Function<? super Upstream, RemappingUpstream> newDecorator(
+            RemappingRequestStrategy requestStrategy, RemappingResponseStrategy responseStrategy) {
+        return builder().requestStrategy(requireNonNull(requestStrategy, "requestStrategy"))
+                        .responseStrategy(requireNonNull(responseStrategy, "responseStrategy"))
+                        .newDecorator();
+    }
+
+    /**
+     * Returns a new {@link RemappingUpstreamBuilder}.
+     */
+    public static RemappingUpstreamBuilder builder() {
+        return new RemappingUpstreamBuilder();
+    }
+
+    @Nullable
+    private final RemappingRequestStrategy requestStrategy;
+    @Nullable
+    private final RemappingResponseStrategy responseStrategy;
+
+    RemappingUpstream(Upstream delegate,
+                      @Nullable RemappingRequestStrategy requestStrategy,
+                      @Nullable RemappingResponseStrategy responseStrategy) {
+        super(delegate);
+        this.requestStrategy = requestStrategy;
+        this.responseStrategy = responseStrategy;
+    }
+
+    @Override
+    public final HttpResponse forward(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        return remapRes(ctx, unwrap().forward(ctx, remapReq(ctx, req)));
+    }
+
+    private HttpRequest remapReq(ServiceRequestContext ctx, HttpRequest req) {
+        if (requestStrategy == null) {
+            return req;
+        }
+        return requestStrategy.remap(ctx, req);
+    }
+
+    private HttpResponse remapRes(ServiceRequestContext ctx, HttpResponse res) {
+        if (responseStrategy == null) {
+            return res;
+        }
+        return responseStrategy.remap(ctx, res);
+    }
+}

--- a/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingUpstreamBuilder.java
+++ b/remapping/src/main/java/dev/gihwan/tollgate/remapping/RemappingUpstreamBuilder.java
@@ -36,51 +36,67 @@ import com.linecorp.armeria.common.HttpRequest;
 import dev.gihwan.tollgate.gateway.Upstream;
 
 /**
- * A builder for {@link RemappingRequestUpstream}.
+ * A builder for {@link RemappingUpstream}.
  */
-public final class RemappingRequestUpstreamBuilder {
+public final class RemappingUpstreamBuilder {
 
     @Nullable
-    private RemappingRequestStrategy strategy;
+    private RemappingRequestStrategy requestStrategy;
+    @Nullable
+    private RemappingResponseStrategy responseStrategy;
 
-    RemappingRequestUpstreamBuilder() {}
+    RemappingUpstreamBuilder() {}
 
     /**
      * Adds a new {@link RemappingRequestStrategy} that remaps {@link HttpRequest} path with the given
      * {@code pathPattern}.
      *
      * @see RemappingRequestPathStrategy#path(String)
-     * @see RemappingRequestUpstreamBuilder#strategy(RemappingRequestStrategy)
+     * @see RemappingUpstreamBuilder#requestStrategy(RemappingRequestStrategy)
      */
-    public RemappingRequestUpstreamBuilder path(String pathPattern) {
-        return strategy(RemappingRequestStrategy.path(pathPattern));
+    public RemappingUpstreamBuilder requestPath(String pathPattern) {
+        return requestStrategy(RemappingRequestStrategy.path(pathPattern));
     }
 
     /**
      * Adds the given {@link RemappingRequestStrategy}.
      */
-    public RemappingRequestUpstreamBuilder strategy(RemappingRequestStrategy strategy) {
-        requireNonNull(strategy, "strategy");
-        if (this.strategy == null) {
-            this.strategy = strategy;
+    public RemappingUpstreamBuilder requestStrategy(RemappingRequestStrategy requestStrategy) {
+        requireNonNull(requestStrategy, "requestStrategy");
+        if (this.requestStrategy == null) {
+            this.requestStrategy = requestStrategy;
         } else {
-            this.strategy = this.strategy.andThen(strategy);
+            this.requestStrategy = this.requestStrategy.andThen(requestStrategy);
         }
         return this;
     }
 
     /**
-     * Builds a new {@link RemappingRequestUpstream} decorator based on the properties of this builder.
+     * Adds the given {@link RemappingResponseStrategy}.
      */
-    public Function<? super Upstream, RemappingRequestUpstream> newDecorator() {
+    public RemappingUpstreamBuilder responseStrategy(RemappingResponseStrategy responseStrategy) {
+        requireNonNull(responseStrategy, "responseStrategy");
+        if (this.responseStrategy == null) {
+            this.responseStrategy = responseStrategy;
+        } else {
+            this.responseStrategy = this.responseStrategy.andThen(responseStrategy);
+        }
+        return this;
+    }
+
+    /**
+     * Builds a new {@link RemappingUpstream} decorator based on the properties of this builder.
+     */
+    public Function<? super Upstream, RemappingUpstream> newDecorator() {
         return this::build;
     }
 
     /**
-     * Builds a new {@link RemappingRequestUpstream} based on the properties of this builder.
+     * Builds a new {@link RemappingUpstream} based on the properties of this builder.
      */
-    public RemappingRequestUpstream build(Upstream delegate) {
-        checkArgument(strategy != null, "Must set at lease one remapping strategy");
-        return new RemappingRequestUpstream(delegate, strategy);
+    public RemappingUpstream build(Upstream delegate) {
+        checkArgument(requestStrategy != null || responseStrategy != null,
+                      "Must set at lease one request or response strategy");
+        return new RemappingUpstream(delegate, requestStrategy, responseStrategy);
     }
 }

--- a/remapping/src/test/java/dev/gihwan/tollgate/remapping/RemappingResponseStrategyTest.java
+++ b/remapping/src/test/java/dev/gihwan/tollgate/remapping/RemappingResponseStrategyTest.java
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.remapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+class RemappingResponseStrategyTest {
+
+    @Test
+    void andThen() {
+        final Queue<String> queue = new ArrayDeque<>();
+
+        final RemappingResponseStrategy strategy1 = (ctx, res) -> {
+            queue.add("strategy1");
+            return res;
+        };
+        final RemappingResponseStrategy strategy2 = (ctx, res) -> {
+            queue.add("strategy2");
+            return res;
+        };
+
+        final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/foo");
+        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        final HttpResponse res = HttpResponse.of("Hello, World!");
+
+        final RemappingResponseStrategy strategy1AndRule2 = strategy1.andThen(strategy2);
+        HttpResponse remapped = strategy1AndRule2.remap(ctx, res);
+        assertThat(remapped).isEqualTo(res);
+        assertThat(queue).containsExactly("strategy1", "strategy2");
+
+        queue.clear();
+        final RemappingResponseStrategy strategy2AndRule1 = strategy2.andThen(strategy1);
+        remapped = strategy2AndRule1.remap(ctx, res);
+        assertThat(remapped).isEqualTo(res);
+        assertThat(queue).containsExactly("strategy2", "strategy1");
+    }
+}

--- a/remapping/src/test/java/dev/gihwan/tollgate/remapping/RemappingUpstreamTest.java
+++ b/remapping/src/test/java/dev/gihwan/tollgate/remapping/RemappingUpstreamTest.java
@@ -40,7 +40,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import dev.gihwan.tollgate.gateway.Upstream;
 import dev.gihwan.tollgate.testing.TestGateway;
 
-class RemappingRequestUpstreamTest {
+class RemappingUpstreamTest {
 
     @RegisterExtension
     static final ServerExtension serviceServer = new ServerExtension() {
@@ -51,12 +51,12 @@ class RemappingRequestUpstreamTest {
     };
 
     @Test
-    void remapPath() {
+    void remapRequestPath() {
         try (TestGateway gateway = withTestGateway(builder -> {
             builder.upstream("/bar", Upstream.builder(serviceServer.httpUri())
-                                             .decorator(RemappingRequestUpstream.builder()
-                                                                                .path("/foo")
-                                                                                .newDecorator())
+                                             .decorator(RemappingUpstream.builder()
+                                                                         .requestPath("/foo")
+                                                                         .newDecorator())
                                              .build());
         })) {
             final WebClient client = WebClient.of(gateway.httpUri());


### PR DESCRIPTION
Prepare to provide remapping `HttpResponse` features.

Make `RemappingRequestUpstream` to `RemappingUpstream`, it is more general. The `RemappingUpstream` consists of `RemappingRequestStrategy` and `RemappingResponseStrategy`. If they set, both or one, remap `HttpRequest` and `HttpResponse` respectively. It is prohibited not to set any req/res strategy.