### PR TITLE
Fix rename

### DIFF
--- a/junit5/src/test/java/dev/gihwan/tollgate/junit5/GatewayExtensionTest.java
+++ b/junit5/src/test/java/dev/gihwan/tollgate/junit5/GatewayExtensionTest.java
@@ -38,7 +38,7 @@ import dev.gihwan.tollgate.gateway.GatewayBuilder;
 class GatewayExtensionTest {
 
     @RegisterExtension
-    static GatewayExtension tollgate = new GatewayExtension() {
+    static GatewayExtension gateway = new GatewayExtension() {
         @Override
         public void configure(GatewayBuilder builder) {
             builder.healthCheck("/health");
@@ -47,17 +47,17 @@ class GatewayExtensionTest {
 
     @Test
     void port() {
-        assertThat(tollgate.httpPort()).isPositive();
+        assertThat(gateway.httpPort()).isPositive();
     }
 
     @Test
     void uri() {
-        assertThat(tollgate.httpUri()).isNotNull();
+        assertThat(gateway.httpUri()).isNotNull();
     }
 
     @Test
     void healthCheck() {
-        final WebClient webClient = WebClient.of(tollgate.httpUri());
+        final WebClient webClient = WebClient.of(gateway.httpUri());
         final AggregatedHttpResponse res = webClient.get("/health").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
     }

--- a/testing/src/test/java/dev/gihwan/tollgate/testing/TestingGatewayTest.java
+++ b/testing/src/test/java/dev/gihwan/tollgate/testing/TestingGatewayTest.java
@@ -39,28 +39,28 @@ class TestingGatewayTest {
 
     @Test
     void port() {
-        try (TestGateway tollgate = withTestGateway(builder -> {
+        try (TestGateway gateway = withTestGateway(builder -> {
             builder.upstream("/foo", Upstream.of("http://127.0.0.1"));
         })) {
-            assertThat(tollgate.httpPort()).isPositive();
+            assertThat(gateway.httpPort()).isPositive();
         }
     }
 
     @Test
     void uri() {
-        try (TestGateway tollgate = withTestGateway(builder -> {
+        try (TestGateway gateway = withTestGateway(builder -> {
             builder.upstream("/foo", Upstream.of("http://127.0.0.1"));
         })) {
-            assertThat(tollgate.httpUri()).isNotNull();
+            assertThat(gateway.httpUri()).isNotNull();
         }
     }
 
     @Test
     void healthCheck() {
-        try (TestGateway tollgate = withTestGateway(builder -> {
+        try (TestGateway gateway = withTestGateway(builder -> {
             builder.healthCheck("/health");
         })) {
-            final WebClient webClient = WebClient.of(tollgate.httpUri());
+            final WebClient webClient = WebClient.of(gateway.httpUri());
             final AggregatedHttpResponse res = webClient.get("/health").aggregate().join();
             assertThat(res.status()).isEqualTo(HttpStatus.OK);
         }


### PR DESCRIPTION
Variable name of `GatewayExtension` and `TestGateway` is not renamed in #88.