### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
+++ b/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
@@ -25,7 +25,7 @@
 package dev.gihwan.tollgate
 
 object Version {
-    const val armeria = "1.3.0"
+    const val armeria = "1.4.0"
 
     const val commonsLang3 = "3.11"
     const val config = "1.4.1"
@@ -34,8 +34,8 @@ object Version {
     const val logback = "1.2.3"
     const val slf4j = "1.7.30"
 
-    const val assertj = "3.18.1"
+    const val assertj = "3.19.0"
     const val awaitility = "4.0.3"
-    const val junit = "5.7.0"
-    const val mockito = "3.7.0"
+    const val junit = "5.7.1"
+    const val mockito = "3.7.7"
 }


### PR DESCRIPTION
Bump `armeria` from 1.3.0 to 1.4.0
Bump `assertj` from 3.18.1 to 3.19.0
Bump `junit` from 5.7.0 to 5.7.1
Bump `mockito` from 3.7.0 to 3.7.7