### PR TITLE
Fix armeria-junit is not `testImplementation` in remapping module

### DIFF
--- a/remapping/build.gradle.kts
+++ b/remapping/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     testImplementation(project(":junit5"))
     testImplementation(Dependency.assertj)
     testImplementation(Dependency.mockito)
-    implementation(Dependency.armeriaJunit)
+    testImplementation(Dependency.armeriaJunit)
 
     testRuntimeOnly(Dependency.junitEngine)
     testRuntimeOnly(Dependency.logback)


### PR DESCRIPTION
`armeria-junit` is used for testing as named. But it is added to dependency as `implementation` instead of `testImplementation`. So, fix it.