### PR TITLE
Allow gateway to serve HTTPS

### DIFF
--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
@@ -24,9 +24,21 @@
 
 package dev.gihwan.tollgate.gateway;
 
+import java.io.File;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+
+import io.netty.handler.ssl.SslContextBuilder;
 
 public final class GatewayBuilder {
 
@@ -39,6 +51,131 @@ public final class GatewayBuilder {
      */
     public GatewayBuilder http(int port) {
         serverBuilder.http(port);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#http(InetSocketAddress)
+     */
+    public GatewayBuilder http(InetSocketAddress localAddress) {
+        serverBuilder.http(localAddress);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#https(int)
+     */
+    public GatewayBuilder https(int port) {
+        serverBuilder.https(port);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#https(InetSocketAddress)
+     */
+    public GatewayBuilder https(InetSocketAddress localAddress) {
+        serverBuilder.https(localAddress);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(File, File)
+     */
+    public GatewayBuilder tls(File keyCertChainFile, File keyFile) {
+        serverBuilder.tls(keyCertChainFile, keyFile);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(File, File, String)
+     */
+    public GatewayBuilder tls(File keyCertChainFile, File keyFile, @Nullable String keyPassword) {
+        serverBuilder.tls(keyCertChainFile, keyFile, keyPassword);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(InputStream, InputStream)
+     */
+    public GatewayBuilder tls(InputStream keyCertChainInputStream, InputStream keyInputStream) {
+        serverBuilder.tls(keyCertChainInputStream, keyInputStream);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(InputStream, InputStream, String)
+     */
+    public GatewayBuilder tls(InputStream keyCertChainInputStream,
+                              InputStream keyInputStream,
+                              @Nullable String keyPassword) {
+        serverBuilder.tls(keyCertChainInputStream, keyInputStream, keyPassword);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(PrivateKey, X509Certificate...)
+     */
+    public GatewayBuilder tls(PrivateKey key, X509Certificate... keyCertChain) {
+        serverBuilder.tls(key, keyCertChain);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(PrivateKey, Iterable)
+     */
+    public GatewayBuilder tls(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
+        serverBuilder.tls(key, keyCertChain);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(PrivateKey, String, X509Certificate...)
+     */
+    public GatewayBuilder tls(PrivateKey key, @Nullable String keyPassword, X509Certificate... keyCertChain) {
+        serverBuilder.tls(key, keyPassword, keyCertChain);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(PrivateKey, String, Iterable)
+     * @return
+     */
+    public GatewayBuilder tls(PrivateKey key,
+                              @Nullable String keyPassword,
+                              Iterable<? extends X509Certificate> keyCertChain) {
+        serverBuilder.tls(key, keyPassword, keyCertChain);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tls(KeyManagerFactory)
+     */
+    public GatewayBuilder tls(KeyManagerFactory keyManagerFactory) {
+        serverBuilder.tls(keyManagerFactory);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tlsSelfSigned()
+     */
+    public GatewayBuilder tlsSelfSigned() {
+        serverBuilder.tlsSelfSigned();
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tlsSelfSigned(boolean)
+     */
+    public GatewayBuilder tlsSelfSigned(boolean tlsSelfSigned) {
+        serverBuilder.tlsSelfSigned(tlsSelfSigned);
+        return this;
+    }
+
+    /**
+     * @see ServerBuilder#tlsCustomizer(Consumer)
+     */
+    public GatewayBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
+        serverBuilder.tlsCustomizer(tlsCustomizer);
         return this;
     }
 

--- a/gateway/src/test/java/dev/gihwan/tollgate/gateway/GatewayTest.java
+++ b/gateway/src/test/java/dev/gihwan/tollgate/gateway/GatewayTest.java
@@ -1,0 +1,90 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class GatewayTest {
+
+    @RegisterExtension
+    static final ServerExtension serviceServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/foo", (ctx, req) -> HttpResponse.of("Hello, World!"));
+        }
+    };
+
+    @Test
+    void http() {
+        final Gateway gateway = Gateway.builder()
+                                       .http(0)
+                                       .upstream("/foo", Upstream.of(serviceServer.httpUri()))
+                                       .build();
+        gateway.start().join();
+
+        assertThat(gateway.activeLocalPort(SessionProtocol.HTTP)).isPositive();
+        assertThatThrownBy(() -> gateway.activeLocalPort(SessionProtocol.HTTPS))
+                .isInstanceOf(IllegalStateException.class);
+
+        final WebClient client = WebClient.of("http://127.0.0.1:" + gateway.activeLocalPort());
+        final AggregatedHttpResponse res = client.get("/foo").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("Hello, World!");
+    }
+
+    @Test
+    void https() {
+        final Gateway gateway = Gateway.builder()
+                                       .https(0)
+                                       .tlsSelfSigned()
+                                       .upstream("/foo", Upstream.of(serviceServer.httpUri()))
+                                       .build();
+        gateway.start().join();
+
+        assertThatThrownBy(() -> gateway.activeLocalPort(SessionProtocol.HTTP))
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(gateway.activeLocalPort(SessionProtocol.HTTPS)).isPositive();
+
+        final WebClient client = WebClient.builder("https://127.0.0.1:" + gateway.activeLocalPort())
+                                          .factory(ClientFactory.insecure())
+                                          .build();
+        final AggregatedHttpResponse res = client.get("/foo").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("Hello, World!");
+    }
+}

--- a/junit5/src/main/java/dev/gihwan/tollgate/junit5/GatewayExtension.java
+++ b/junit5/src/main/java/dev/gihwan/tollgate/junit5/GatewayExtension.java
@@ -70,6 +70,13 @@ public abstract class GatewayExtension extends AbstractAllOrEachExtension {
     }
 
     /**
+     * @see TestGateway#httpsPort()
+     */
+    public int httpsPort() {
+        return delegate.httpsPort();
+    }
+
+    /**
      * @see TestGateway#port(SessionProtocol)
      */
     public int port(SessionProtocol protocol) {
@@ -81,5 +88,12 @@ public abstract class GatewayExtension extends AbstractAllOrEachExtension {
      */
     public URI httpUri() {
         return delegate.httpUri();
+    }
+
+    /**
+     * @see TestGateway#httpsUri()
+     */
+    public URI httpsUri() {
+        return delegate.httpsUri();
     }
 }

--- a/junit5/src/test/java/dev/gihwan/tollgate/junit5/GatewayExtensionTest.java
+++ b/junit5/src/test/java/dev/gihwan/tollgate/junit5/GatewayExtensionTest.java
@@ -41,6 +41,8 @@ class GatewayExtensionTest {
     static GatewayExtension gateway = new GatewayExtension() {
         @Override
         public void configure(GatewayBuilder builder) {
+            builder.http(0);
+            builder.https(0).tlsSelfSigned();
             builder.healthCheck("/health");
         }
     };
@@ -48,11 +50,13 @@ class GatewayExtensionTest {
     @Test
     void port() {
         assertThat(gateway.httpPort()).isPositive();
+        assertThat(gateway.httpsPort()).isPositive();
     }
 
     @Test
     void uri() {
         assertThat(gateway.httpUri()).isNotNull();
+        assertThat(gateway.httpsUri()).isNotNull();
     }
 
     @Test

--- a/testing/src/main/java/dev/gihwan/tollgate/testing/TestGateway.java
+++ b/testing/src/main/java/dev/gihwan/tollgate/testing/TestGateway.java
@@ -114,6 +114,13 @@ public abstract class TestGateway implements SafeCloseable {
     }
 
     /**
+     * Returns the local port which the {@link Gateway} serves HTTPS.
+     */
+    public int httpsPort() {
+        return port(SessionProtocol.HTTPS);
+    }
+
+    /**
      * Returns the local port which the {@link Gateway} serves the given {@code protocol}.
      */
     public int port(SessionProtocol protocol) {
@@ -126,5 +133,12 @@ public abstract class TestGateway implements SafeCloseable {
      */
     public URI httpUri() {
         return URI.create("http://127.0.0.1:" + httpPort());
+    }
+
+    /**
+     * Returns the {@link URI} which the {@link Gateway} serves HTTPS.
+     */
+    public URI httpsUri() {
+        return URI.create("http://127.0.0.1:" + httpsPort());
     }
 }

--- a/testing/src/test/java/dev/gihwan/tollgate/testing/TestGatewayTest.java
+++ b/testing/src/test/java/dev/gihwan/tollgate/testing/TestGatewayTest.java
@@ -35,23 +35,29 @@ import com.linecorp.armeria.common.HttpStatus;
 
 import dev.gihwan.tollgate.gateway.Upstream;
 
-class TestingGatewayTest {
+class TestGatewayTest {
 
     @Test
     void port() {
         try (TestGateway gateway = withTestGateway(builder -> {
+            builder.http(0);
+            builder.https(0).tlsSelfSigned();
             builder.upstream("/foo", Upstream.of("http://127.0.0.1"));
         })) {
             assertThat(gateway.httpPort()).isPositive();
+            assertThat(gateway.httpsPort()).isPositive();
         }
     }
 
     @Test
     void uri() {
         try (TestGateway gateway = withTestGateway(builder -> {
+            builder.http(0);
+            builder.https(0).tlsSelfSigned();
             builder.upstream("/foo", Upstream.of("http://127.0.0.1"));
         })) {
             assertThat(gateway.httpUri()).isNotNull();
+            assertThat(gateway.httpsUri()).isNotNull();
         }
     }
 


### PR DESCRIPTION
To serve HTTPS.
Users can specify HTTPS port with their certificate and its private key files. As supported by Armeria, Tollgate also supports `tlsSelfSigned`.