### PR TITLE
Enable to decorate with Armeria decorator in `UpstreamBindingBuilder`

### DIFF
--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
@@ -192,6 +192,9 @@ public final class GatewayBuilder {
         return new UpstreamBindingBuilder(this, serverBuilder.route());
     }
 
+    /**
+     * Binds the given {@link Upstream} at the given {@code pathPattern}.
+     */
     public GatewayBuilder upstream(String pathPattern, Upstream upstream) {
         return route().path(pathPattern).build(upstream);
     }

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBindingBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBindingBuilder.java
@@ -24,13 +24,24 @@
 
 package dev.gihwan.tollgate.gateway;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
 import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceBindingBuilder;
 
 public final class UpstreamBindingBuilder {
+
+    @Nullable
+    private Function<? super Upstream, ? extends Upstream> decorator;
 
     private final GatewayBuilder gatewayBuilder;
     private final ServiceBindingBuilder serviceBindingBuilder;
@@ -226,8 +237,74 @@ public final class UpstreamBindingBuilder {
         return this;
     }
 
+    /**
+     * Decorates a {@link Upstream} with the given {@code decorator}.
+     */
+    public UpstreamBindingBuilder decorator(Function<? super Upstream, ? extends Upstream> decorator) {
+        requireNonNull(decorator, "decorator");
+        if (this.decorator == null) {
+            this.decorator = decorator;
+        } else {
+            this.decorator = this.decorator.andThen(decorator);
+        }
+        return this;
+    }
+
+    /**
+     * Decorates a {@link Upstream} with the given {@code decorators}, in the order of iteration.
+     */
+    @SafeVarargs
+    public final UpstreamBindingBuilder decorators(
+            Function<? super Upstream, ? extends Upstream>... decorators) {
+        return decorators(ImmutableList.copyOf(requireNonNull(decorators, "decorators")));
+    }
+
+    /**
+     * Decorates a {@link Upstream} with the given {@code decorators}, in the order of iteration.
+     */
+    public UpstreamBindingBuilder decorators(
+            Iterable<Function<? super Upstream, ? extends Upstream>> decorators) {
+        requireNonNull(decorators, "decorators");
+        for (Function<? super Upstream, ? extends Upstream> decorator : decorators) {
+            this.decorator(requireNonNull(decorator, "decorator"));
+        }
+        return this;
+    }
+
+    /**
+     * @see ServiceBindingBuilder#decorator(Function)
+     */
+    public UpstreamBindingBuilder armeriaDecorator(
+            Function<? super HttpService, ? extends HttpService> armeriaDecorator) {
+        serviceBindingBuilder.decorator(armeriaDecorator);
+        return this;
+    }
+
+    /**
+     * @see ServiceBindingBuilder#decorators(Function[])
+     */
+    @SafeVarargs
+    public final UpstreamBindingBuilder armeriaDecorators(
+            Function<? super HttpService, ? extends HttpService>... armeriaDecorators) {
+        serviceBindingBuilder.decorators(armeriaDecorators);
+        return this;
+    }
+
+    /**
+     * @see ServiceBindingBuilder#decorators(Iterable)
+     */
+    public UpstreamBindingBuilder armeriaDecorators(
+            Iterable<? extends Function<? super HttpService, ? extends HttpService>> armeriaDecorators) {
+        serviceBindingBuilder.decorators(armeriaDecorators);
+        return this;
+    }
+
     public final GatewayBuilder build(Upstream upstream) {
-        serviceBindingBuilder.build(new UpstreamHttpService(upstream));
+        Upstream decoratedUpstream = upstream;
+        if (decorator != null) {
+            decoratedUpstream = upstream.decorate(decorator);
+        }
+        serviceBindingBuilder.build(new UpstreamHttpService(decoratedUpstream));
         return gatewayBuilder;
     }
 }

--- a/gateway/src/test/java/dev/gihwan/tollgate/gateway/UpstreamBindingBuilderTest.java
+++ b/gateway/src/test/java/dev/gihwan/tollgate/gateway/UpstreamBindingBuilderTest.java
@@ -1,0 +1,194 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.gateway;
+
+import static dev.gihwan.tollgate.testing.TestGateway.withTestGateway;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import dev.gihwan.tollgate.testing.TestGateway;
+
+class UpstreamBindingBuilderTest {
+
+    @RegisterExtension
+    static final ServerExtension serviceServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/foo", (ctx, req) -> HttpResponse.of("Hello, World!"));
+        }
+    };
+
+    @Test
+    void decorator() {
+        final Queue<String> queue = new ArrayDeque<>();
+
+        try (TestGateway gateway = withTestGateway(builder -> {
+            builder.route()
+                   .path("/foo")
+                   .decorator(delegate -> {
+                       queue.add("decorator1");
+                       return delegate;
+                   })
+                   .decorator(delegate -> {
+                       queue.add("decorator2");
+                       return delegate;
+                   })
+                   .build(Upstream.of(serviceServer.httpUri()));
+        })) {
+            final WebClient client = WebClient.of(gateway.httpUri());
+            client.get("/foo").aggregate().join();
+
+            assertThat(queue).containsExactly("decorator1", "decorator2");
+        }
+    }
+
+    @Test
+    void decorators() {
+        final Queue<String> queue = new ArrayDeque<>();
+
+        try (TestGateway gateway = withTestGateway(builder -> {
+            builder.route()
+                   .path("/foo")
+                   .decorators(delegate -> {
+                       queue.add("decorator1");
+                       return delegate;
+                   }, delegate -> {
+                       queue.add("decorator2");
+                       return delegate;
+                   })
+                   .build(Upstream.of(serviceServer.httpUri()));
+        })) {
+            final WebClient client = WebClient.of(gateway.httpUri());
+            client.get("/foo").aggregate().join();
+
+            assertThat(queue).containsExactly("decorator1", "decorator2");
+        }
+    }
+
+    @Test
+    void armeriaDecorator() {
+        final Queue<String> queue = new ArrayDeque<>();
+
+        try (TestGateway gateway = withTestGateway(builder -> {
+            builder.route()
+                   .path("/foo")
+                   .armeriaDecorator(delegate -> {
+                       queue.add("decorator1");
+                       return delegate;
+                   })
+                   .armeriaDecorator(delegate -> {
+                       queue.add("decorator2");
+                       return delegate;
+                   })
+                   .build(Upstream.of(serviceServer.httpUri()));
+        })) {
+            final WebClient client = WebClient.of(gateway.httpUri());
+            client.get("/foo").aggregate().join();
+
+            assertThat(queue).containsExactly("decorator1", "decorator2");
+        }
+    }
+
+    @Test
+    void armeriaDecorators() {
+        final Queue<String> queue = new ArrayDeque<>();
+
+        try (TestGateway gateway = withTestGateway(builder -> {
+            builder.route()
+                   .path("/foo")
+                   .armeriaDecorators(delegate -> {
+                       queue.add("decorator1");
+                       return delegate;
+                   }, delegate -> {
+                       queue.add("decorator2");
+                       return delegate;
+                   })
+                   .build(Upstream.of(serviceServer.httpUri()));
+        })) {
+            final WebClient client = WebClient.of(gateway.httpUri());
+            client.get("/foo").aggregate().join();
+
+            assertThat(queue).containsExactly("decorator1", "decorator2");
+        }
+    }
+
+    @Test
+    void decoratorAndArmeriaDecorator() {
+        final Queue<String> queue = new ArrayDeque<>();
+
+        try (TestGateway gateway = withTestGateway(builder -> {
+            builder.route()
+                   .path("/foo")
+                   .decorator(delegate -> {
+                       queue.add("decorator1");
+                       return delegate;
+                   })
+                   .armeriaDecorator(delegate -> {
+                       queue.add("decorator2");
+                       return delegate;
+                   })
+                   .build(Upstream.of(serviceServer.httpUri()));
+        })) {
+            final WebClient client = WebClient.of(gateway.httpUri());
+            client.get("/foo").aggregate().join();
+
+            assertThat(queue).containsExactly("decorator1", "decorator2");
+        }
+    }
+
+    @Test
+    void armeriaDecoratorAndDecorator() {
+        final Queue<String> queue = new ArrayDeque<>();
+
+        try (TestGateway gateway = withTestGateway(builder -> {
+            builder.route()
+                   .path("/foo")
+                   .armeriaDecorator(delegate -> {
+                       queue.add("decorator1");
+                       return delegate;
+                   })
+                   .decorator(delegate -> {
+                       queue.add("decorator2");
+                       return delegate;
+                   })
+                   .build(Upstream.of(serviceServer.httpUri()));
+        })) {
+            final WebClient client = WebClient.of(gateway.httpUri());
+            client.get("/foo").aggregate().join();
+
+            assertThat(queue).containsExactly("decorator2", "decorator1"); // decorates Armeria decorator later
+        }
+    }
+}


### PR DESCRIPTION
Enable to decorate `Upstream` with Armeria decorator using `armeriaDecorator` and `armeriaDecorators` in `UpstreamBindingBuilder`. Additionally, add basic `decorator` and `decorators` also. Armeria decorators are decorated after Tollgate decorator, because Tollgate `Upstream` is a kind of wrapper of Armeria service.
It will be useful for user who want to use Armeria's great decorators or migrate from Armeria to Tollgate.
But, this is not primary feature, don't allow to add Armeria decorator in `GatewayBuilder`.