### PR TITLE
Check whether parameter is null in public interface

### DIFF
--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/DecoratingUpstream.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/DecoratingUpstream.java
@@ -24,6 +24,8 @@
 
 package dev.gihwan.tollgate.gateway;
 
+import static java.util.Objects.requireNonNull;
+
 import com.linecorp.armeria.common.util.AbstractUnwrappable;
 
 /**
@@ -32,6 +34,6 @@ import com.linecorp.armeria.common.util.AbstractUnwrappable;
 public abstract class DecoratingUpstream extends AbstractUnwrappable<Upstream> implements Upstream {
 
     protected DecoratingUpstream(Upstream delegate) {
-        super(delegate);
+        super(requireNonNull(delegate, "delegate"));
     }
 }

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/Gateway.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/Gateway.java
@@ -24,6 +24,8 @@
 
 package dev.gihwan.tollgate.gateway;
 
+import static java.util.Objects.requireNonNull;
+
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -71,7 +73,7 @@ public final class Gateway {
      */
     @Nullable
     public ServerPort activePort(SessionProtocol protocol) {
-        return server.activePort(protocol);
+        return server.activePort(requireNonNull(protocol, "protocol"));
     }
 
     /**
@@ -85,7 +87,7 @@ public final class Gateway {
      * @see Server#activeLocalPort(SessionProtocol)
      */
     public int activeLocalPort(SessionProtocol protocol) {
-        return server.activeLocalPort(protocol);
+        return server.activeLocalPort(requireNonNull(protocol, "protocol"));
     }
 
     public CompletableFuture<Void> start() {

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
@@ -64,7 +64,7 @@ public final class GatewayBuilder {
      * @see ServerBuilder#http(InetSocketAddress)
      */
     public GatewayBuilder http(InetSocketAddress localAddress) {
-        serverBuilder.http(localAddress);
+        serverBuilder.http(requireNonNull(localAddress, "localAddress"));
         return this;
     }
 
@@ -80,7 +80,7 @@ public final class GatewayBuilder {
      * @see ServerBuilder#https(InetSocketAddress)
      */
     public GatewayBuilder https(InetSocketAddress localAddress) {
-        serverBuilder.https(localAddress);
+        serverBuilder.https(requireNonNull(localAddress, "localAddress"));
         return this;
     }
 
@@ -88,7 +88,8 @@ public final class GatewayBuilder {
      * @see ServerBuilder#tls(File, File)
      */
     public GatewayBuilder tls(File keyCertChainFile, File keyFile) {
-        serverBuilder.tls(keyCertChainFile, keyFile);
+        serverBuilder.tls(requireNonNull(keyCertChainFile, "keyCertChainFile"),
+                          requireNonNull(keyFile, "keyFile"));
         return this;
     }
 
@@ -96,7 +97,9 @@ public final class GatewayBuilder {
      * @see ServerBuilder#tls(File, File, String)
      */
     public GatewayBuilder tls(File keyCertChainFile, File keyFile, @Nullable String keyPassword) {
-        serverBuilder.tls(keyCertChainFile, keyFile, keyPassword);
+        serverBuilder.tls(requireNonNull(keyCertChainFile, "keyCertChainFile"),
+                          requireNonNull(keyFile, "keyFile"),
+                          keyPassword);
         return this;
     }
 
@@ -104,7 +107,8 @@ public final class GatewayBuilder {
      * @see ServerBuilder#tls(InputStream, InputStream)
      */
     public GatewayBuilder tls(InputStream keyCertChainInputStream, InputStream keyInputStream) {
-        serverBuilder.tls(keyCertChainInputStream, keyInputStream);
+        serverBuilder.tls(requireNonNull(keyCertChainInputStream, "keyCertChainInputStream"),
+                          requireNonNull(keyInputStream, "keyInputStream"));
         return this;
     }
 
@@ -114,7 +118,9 @@ public final class GatewayBuilder {
     public GatewayBuilder tls(InputStream keyCertChainInputStream,
                               InputStream keyInputStream,
                               @Nullable String keyPassword) {
-        serverBuilder.tls(keyCertChainInputStream, keyInputStream, keyPassword);
+        serverBuilder.tls(requireNonNull(keyCertChainInputStream, "keyCertChainInputStream"),
+                          requireNonNull(keyInputStream, "keyInputStream"),
+                          keyPassword);
         return this;
     }
 
@@ -122,7 +128,7 @@ public final class GatewayBuilder {
      * @see ServerBuilder#tls(PrivateKey, X509Certificate...)
      */
     public GatewayBuilder tls(PrivateKey key, X509Certificate... keyCertChain) {
-        serverBuilder.tls(key, keyCertChain);
+        serverBuilder.tls(requireNonNull(key, "key"), requireNonNull(keyCertChain, "keyCertChain"));
         return this;
     }
 
@@ -130,7 +136,7 @@ public final class GatewayBuilder {
      * @see ServerBuilder#tls(PrivateKey, Iterable)
      */
     public GatewayBuilder tls(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
-        serverBuilder.tls(key, keyCertChain);
+        serverBuilder.tls(requireNonNull(key, "key"), requireNonNull(keyCertChain, "keyCertChain"));
         return this;
     }
 
@@ -138,7 +144,9 @@ public final class GatewayBuilder {
      * @see ServerBuilder#tls(PrivateKey, String, X509Certificate...)
      */
     public GatewayBuilder tls(PrivateKey key, @Nullable String keyPassword, X509Certificate... keyCertChain) {
-        serverBuilder.tls(key, keyPassword, keyCertChain);
+        serverBuilder.tls(requireNonNull(key, "key"),
+                          keyPassword,
+                          requireNonNull(keyCertChain, "keyCertChain"));
         return this;
     }
 
@@ -149,7 +157,9 @@ public final class GatewayBuilder {
     public GatewayBuilder tls(PrivateKey key,
                               @Nullable String keyPassword,
                               Iterable<? extends X509Certificate> keyCertChain) {
-        serverBuilder.tls(key, keyPassword, keyCertChain);
+        serverBuilder.tls(requireNonNull(key, "key"),
+                          keyPassword,
+                          requireNonNull(keyCertChain, "keyCertChain"));
         return this;
     }
 
@@ -157,7 +167,7 @@ public final class GatewayBuilder {
      * @see ServerBuilder#tls(KeyManagerFactory)
      */
     public GatewayBuilder tls(KeyManagerFactory keyManagerFactory) {
-        serverBuilder.tls(keyManagerFactory);
+        serverBuilder.tls(requireNonNull(keyManagerFactory, "keyManagerFactory"));
         return this;
     }
 
@@ -181,7 +191,7 @@ public final class GatewayBuilder {
      * @see ServerBuilder#tlsCustomizer(Consumer)
      */
     public GatewayBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
-        serverBuilder.tlsCustomizer(tlsCustomizer);
+        serverBuilder.tlsCustomizer(requireNonNull(tlsCustomizer, "tlsCustomizer"));
         return this;
     }
 
@@ -190,7 +200,8 @@ public final class GatewayBuilder {
     }
 
     public GatewayBuilder healthCheck(String healthCheckPath, HealthCheckService healthCheckService) {
-        serverBuilder.service(healthCheckPath, healthCheckService);
+        serverBuilder.service(requireNonNull(healthCheckPath, "healthCheckPath"),
+                              requireNonNull(healthCheckService, "healthCheckService"));
         return this;
     }
 

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/Upstream.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/Upstream.java
@@ -85,8 +85,7 @@ public interface Upstream extends Unwrappable {
 
     @Override
     default <T> T as(Class<T> type) {
-        requireNonNull(type, "type");
-        return Unwrappable.super.as(type);
+        return Unwrappable.super.as(requireNonNull(type, "type"));
     }
 
     @Override
@@ -95,6 +94,8 @@ public interface Upstream extends Unwrappable {
     }
 
     default <T extends Upstream> T decorate(Function<? super Upstream, T> decorator) {
+        requireNonNull(decorator, "decorator");
+
         final T newUpstream = decorator.apply(this);
 
         if (newUpstream == null) {

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBindingBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBindingBuilder.java
@@ -55,7 +55,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#path(String)
      */
     public UpstreamBindingBuilder path(String pathPattern) {
-        serviceBindingBuilder.path(pathPattern);
+        serviceBindingBuilder.path(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -63,7 +63,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#pathPrefix(String)
      */
     public UpstreamBindingBuilder pathPrefix(String prefix) {
-        serviceBindingBuilder.pathPrefix(prefix);
+        serviceBindingBuilder.pathPrefix(requireNonNull(prefix, "prefix"));
         return this;
     }
 
@@ -71,7 +71,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#methods(HttpMethod...)
      */
     public UpstreamBindingBuilder methods(HttpMethod... methods) {
-        serviceBindingBuilder.methods(methods);
+        serviceBindingBuilder.methods(requireNonNull(methods, "methods"));
         return this;
     }
 
@@ -79,7 +79,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#methods(Iterable)
      */
     public UpstreamBindingBuilder methods(Iterable<HttpMethod> methods) {
-        serviceBindingBuilder.methods(methods);
+        serviceBindingBuilder.methods(requireNonNull(methods, "methods"));
         return this;
     }
 
@@ -87,7 +87,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#get(String)
      */
     public UpstreamBindingBuilder get(String pathPattern) {
-        serviceBindingBuilder.get(pathPattern);
+        serviceBindingBuilder.get(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -95,7 +95,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#post(String)
      */
     public UpstreamBindingBuilder post(String pathPattern) {
-        serviceBindingBuilder.post(pathPattern);
+        serviceBindingBuilder.post(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -103,7 +103,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#put(String)
      */
     public UpstreamBindingBuilder put(String pathPattern) {
-        serviceBindingBuilder.put(pathPattern);
+        serviceBindingBuilder.put(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -111,7 +111,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#patch(String)
      */
     public UpstreamBindingBuilder patch(String pathPattern) {
-        serviceBindingBuilder.patch(pathPattern);
+        serviceBindingBuilder.patch(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -119,7 +119,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#delete(String)
      */
     public UpstreamBindingBuilder delete(String pathPattern) {
-        serviceBindingBuilder.delete(pathPattern);
+        serviceBindingBuilder.delete(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -127,7 +127,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#options(String)
      */
     public UpstreamBindingBuilder options(String pathPattern) {
-        serviceBindingBuilder.options(pathPattern);
+        serviceBindingBuilder.options(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -135,7 +135,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#head(String)
      */
     public UpstreamBindingBuilder head(String pathPattern) {
-        serviceBindingBuilder.head(pathPattern);
+        serviceBindingBuilder.head(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -143,7 +143,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#trace(String)
      */
     public UpstreamBindingBuilder trace(String pathPattern) {
-        serviceBindingBuilder.trace(pathPattern);
+        serviceBindingBuilder.trace(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -151,7 +151,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#connect(String)
      */
     public UpstreamBindingBuilder connect(String pathPattern) {
-        serviceBindingBuilder.connect(pathPattern);
+        serviceBindingBuilder.connect(requireNonNull(pathPattern, "pathPattern"));
         return this;
     }
 
@@ -159,7 +159,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#consumes(MediaType...)
      */
     public UpstreamBindingBuilder consumes(MediaType... consumeTypes) {
-        serviceBindingBuilder.consumes(consumeTypes);
+        serviceBindingBuilder.consumes(requireNonNull(consumeTypes, "consumeTypes"));
         return this;
     }
 
@@ -167,7 +167,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#consumes(Iterable)
      */
     public UpstreamBindingBuilder consumes(Iterable<MediaType> consumeTypes) {
-        serviceBindingBuilder.consumes(consumeTypes);
+        serviceBindingBuilder.consumes(requireNonNull(consumeTypes, "consumeTypes"));
         return this;
     }
 
@@ -175,7 +175,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#produces(MediaType...)
      */
     public UpstreamBindingBuilder produces(MediaType... produceTypes) {
-        serviceBindingBuilder.produces(produceTypes);
+        serviceBindingBuilder.produces(requireNonNull(produceTypes, "produceTypes"));
         return this;
     }
 
@@ -183,7 +183,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#produces(Iterable)
      */
     public UpstreamBindingBuilder produces(Iterable<MediaType> produceTypes) {
-        serviceBindingBuilder.produces(produceTypes);
+        serviceBindingBuilder.produces(requireNonNull(produceTypes, "produceTypes"));
         return this;
     }
 
@@ -191,7 +191,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#matchesParams(String...)
      */
     public UpstreamBindingBuilder matchesParams(String... paramPredicates) {
-        serviceBindingBuilder.matchesParams(paramPredicates);
+        serviceBindingBuilder.matchesParams(requireNonNull(paramPredicates, "paramPredicates"));
         return this;
     }
 
@@ -199,7 +199,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#matchesParams(Iterable)
      */
     public UpstreamBindingBuilder matchesParams(Iterable<String> paramPredicates) {
-        serviceBindingBuilder.matchesParams(paramPredicates);
+        serviceBindingBuilder.matchesParams(requireNonNull(paramPredicates, "paramPredicates"));
         return this;
     }
 
@@ -208,7 +208,8 @@ public final class UpstreamBindingBuilder {
      */
     public UpstreamBindingBuilder matchesParams(String paramName,
                                                 Predicate<? super String> valuePredicate) {
-        serviceBindingBuilder.matchesParams(paramName, valuePredicate);
+        serviceBindingBuilder.matchesParams(requireNonNull(paramName, "paramName"),
+                                            requireNonNull(valuePredicate, "valuePredicate"));
         return this;
     }
 
@@ -216,7 +217,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#matchesHeaders(String...)
      */
     public UpstreamBindingBuilder matchesHeaders(String... headerPredicates) {
-        serviceBindingBuilder.matchesHeaders(headerPredicates);
+        serviceBindingBuilder.matchesHeaders(requireNonNull(headerPredicates, "headerPredicates"));
         return this;
     }
 
@@ -224,7 +225,7 @@ public final class UpstreamBindingBuilder {
      * @see ServiceBindingBuilder#matchesHeaders(Iterable)
      */
     public UpstreamBindingBuilder matchesHeaders(Iterable<String> headerPredicates) {
-        serviceBindingBuilder.matchesHeaders(headerPredicates);
+        serviceBindingBuilder.matchesHeaders(requireNonNull(headerPredicates, "headerPredicates"));
         return this;
     }
 
@@ -233,7 +234,8 @@ public final class UpstreamBindingBuilder {
      */
     public UpstreamBindingBuilder matchesHeaders(CharSequence headerName,
                                                  Predicate<? super String> valuePredicate) {
-        serviceBindingBuilder.matchesHeaders(headerName, valuePredicate);
+        serviceBindingBuilder.matchesHeaders(requireNonNull(headerName, "headerName"),
+                                             requireNonNull(valuePredicate, "valuePredicate"));
         return this;
     }
 
@@ -276,7 +278,7 @@ public final class UpstreamBindingBuilder {
      */
     public UpstreamBindingBuilder armeriaDecorator(
             Function<? super HttpService, ? extends HttpService> armeriaDecorator) {
-        serviceBindingBuilder.decorator(armeriaDecorator);
+        serviceBindingBuilder.decorator(requireNonNull(armeriaDecorator, "armeriaDecorator"));
         return this;
     }
 
@@ -286,7 +288,7 @@ public final class UpstreamBindingBuilder {
     @SafeVarargs
     public final UpstreamBindingBuilder armeriaDecorators(
             Function<? super HttpService, ? extends HttpService>... armeriaDecorators) {
-        serviceBindingBuilder.decorators(armeriaDecorators);
+        serviceBindingBuilder.decorators(requireNonNull(armeriaDecorators, "armeriaDecorators"));
         return this;
     }
 
@@ -295,7 +297,7 @@ public final class UpstreamBindingBuilder {
      */
     public UpstreamBindingBuilder armeriaDecorators(
             Iterable<? extends Function<? super HttpService, ? extends HttpService>> armeriaDecorators) {
-        serviceBindingBuilder.decorators(armeriaDecorators);
+        serviceBindingBuilder.decorators(requireNonNull(armeriaDecorators, "armeriaDecorators"));
         return this;
     }
 

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBuilder.java
@@ -44,15 +44,18 @@ public final class UpstreamBuilder {
     private final WebClientBuilder clientBuilder;
 
     UpstreamBuilder(URI uri) {
-        clientBuilder = WebClient.builder(uri);
+        clientBuilder = WebClient.builder(requireNonNull(uri, "uri"));
     }
 
     UpstreamBuilder(SessionProtocol protocol, EndpointGroup endpointGroup) {
-        clientBuilder = WebClient.builder(protocol, endpointGroup);
+        clientBuilder = WebClient.builder(requireNonNull(protocol, "protocol"),
+                                          requireNonNull(endpointGroup, "endpointGroup"));
     }
 
     UpstreamBuilder(SessionProtocol protocol, EndpointGroup endpointGroup, String path) {
-        clientBuilder = WebClient.builder(protocol, endpointGroup, path);
+        clientBuilder = WebClient.builder(requireNonNull(protocol, "protocol"),
+                                          requireNonNull(endpointGroup, "endpointGroup"),
+                                          requireNonNull(path, "path"));
     }
 
     public UpstreamBuilder decorator(Function<? super Upstream, ? extends Upstream> decorator) {

--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/DefaultHoconGatewayConfigurator.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/DefaultHoconGatewayConfigurator.java
@@ -25,6 +25,7 @@
 package dev.gihwan.tollgate.hocon;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Set;
@@ -49,6 +50,9 @@ enum DefaultHoconGatewayConfigurator implements HoconGatewayConfigurator {
 
     @Override
     public void configure(GatewayBuilder builder, Config config) {
+        requireNonNull(builder, "builder");
+        requireNonNull(config, "config");
+
         if (config.hasPath("tollgate.port")) {
             builder.http(config.getInt("tollgate.port"));
         }

--- a/testing/src/main/java/dev/gihwan/tollgate/testing/TestGateway.java
+++ b/testing/src/main/java/dev/gihwan/tollgate/testing/TestGateway.java
@@ -125,7 +125,7 @@ public abstract class TestGateway implements SafeCloseable {
      */
     public int port(SessionProtocol protocol) {
         checkState(delegate != null, "gateway did not start.");
-        return delegate.activeLocalPort(protocol);
+        return delegate.activeLocalPort(requireNonNull(protocol, "protocol"));
     }
 
     /**


### PR DESCRIPTION
To ensure non-null, check whether a parameter is `null` in public interface. Although Armeria checks null, but we also check null because we treat Armeria implementation as black box. Therefore, if don'y call our other public interface, always check null using `requireNonNull`.