### PR TITLE
Forward `HttpRequest`s in `UpstreamHttpService` instead of `Upstream`

### DIFF
--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/DefaultUpstream.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/DefaultUpstream.java
@@ -24,15 +24,11 @@
 
 package dev.gihwan.tollgate.gateway;
 
-import java.util.concurrent.CompletableFuture;
-
-import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.ServiceRequestContext;
 
+/**
+ * The default implementation of {@link Upstream}.
+ */
 final class DefaultUpstream implements Upstream {
 
     private final WebClient client;
@@ -42,26 +38,7 @@ final class DefaultUpstream implements Upstream {
     }
 
     @Override
-    public HttpResponse forward(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        final CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
-        final HttpResponse res = HttpResponse.from(resFuture);
-        client.execute(req).aggregate().handleAsync((aggregated, cause) -> {
-            if (cause != null) {
-                resolveException(resFuture, cause);
-                return null;
-            }
-
-            resFuture.complete(aggregated.toHttpResponse());
-            return null;
-        }, ctx.eventLoop());
-        return res;
-    }
-
-    private static void resolveException(CompletableFuture<HttpResponse> responseFuture, Throwable t) {
-        if (t instanceof UnprocessedRequestException) {
-            responseFuture.complete(HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE));
-            return;
-        }
-        responseFuture.completeExceptionally(t);
+    public WebClient client() {
+        return client;
     }
 }

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/Upstream.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/Upstream.java
@@ -28,56 +28,94 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 
-import javax.annotation.CheckReturnValue;
-
+import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.server.ServiceRequestContext;
 
+/**
+ * A upstream which forwards {@link HttpRequest}s from client to the specified destination.
+ */
 public interface Upstream {
 
+    /**
+     * Returns a new {@link Upstream} which forwards to the given {@code uri}.
+     */
     static Upstream of(String uri) {
         return builder(uri).build();
     }
 
+    /**
+     * Returns a new {@link Upstream} which forward to the given {@link URI}.
+     */
     static Upstream of(URI uri) {
         return builder(uri).build();
     }
 
+    /**
+     * Returns a new {@link Upstream} which forwards to the given {@link EndpointGroup} with the given
+     * {@code protocol}.
+     */
     static Upstream of(String protocol, EndpointGroup endpointGroup) {
         return builder(protocol, endpointGroup).build();
     }
 
+    /**
+     * Returns a new {@link Upstream} which forwards to the given {@link EndpointGroup}  with the given
+     * {@code protocol} and {@code path}.
+     */
     static Upstream of(String protocol, EndpointGroup endpointGroup, String path) {
         return builder(protocol, endpointGroup, path).build();
     }
 
+    /**
+     * Returns a new {@link UpstreamBuilder} based on the given {@code uri}.
+     */
     static UpstreamBuilder builder(String uri) {
         return builder(URI.create(requireNonNull(uri, "uri")));
     }
 
+    /**
+     * Returns a new {@link UpstreamBuilder} based on the given {@link URI}.
+     */
     static UpstreamBuilder builder(URI uri) {
         return new UpstreamBuilder(requireNonNull(uri, "uri"));
     }
 
+    /**
+     * Returns a new {@link UpstreamBuilder} based on the given {@link EndpointGroup} with the given
+     * {@code protocol}.
+     */
     static UpstreamBuilder builder(String protocol, EndpointGroup endpointGroup) {
         return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup);
     }
 
+    /**
+     * Returns a new {@link UpstreamBuilder} based on the given {@link EndpointGroup} with the given
+     * {@link SessionProtocol}.
+     */
     static UpstreamBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
         return new UpstreamBuilder(protocol, endpointGroup);
     }
 
+    /**
+     * Returns a new {@link UpstreamBuilder} based on the given {@link EndpointGroup} with the given
+     * {@code protocol} and {@code path}.
+     */
     static UpstreamBuilder builder(String protocol, EndpointGroup endpointGroup, String path) {
         return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup, path);
     }
 
+    /**
+     * Returns a new {@link UpstreamBuilder} based on the given {@link EndpointGroup} with the given
+     * {@link SessionProtocol} and {@code path}.
+     */
     static UpstreamBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup, String path) {
         return new UpstreamBuilder(protocol, endpointGroup, path);
     }
 
-    @CheckReturnValue
-    HttpResponse forward(ServiceRequestContext ctx, HttpRequest req) throws Exception;
+    /**
+     * Returns the {@link WebClient} of this upstream.
+     */
+    WebClient client();
 }

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamHttpService.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamHttpService.java
@@ -24,11 +24,18 @@
 
 package dev.gihwan.tollgate.gateway;
 
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
+/**
+ * A {@link HttpService} which forwards {@link HttpRequest}s to the specified {@link Upstream}.
+ */
 final class UpstreamHttpService implements HttpService {
 
     private final Upstream upstream;
@@ -39,6 +46,25 @@ final class UpstreamHttpService implements HttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        return upstream.forward(ctx, req);
+        final CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
+        final HttpResponse res = HttpResponse.from(resFuture);
+        upstream.client().execute(req).aggregate().handleAsync((aggregated, cause) -> {
+            if (cause != null) {
+                resolveException(resFuture, cause);
+                return null;
+            }
+
+            resFuture.complete(aggregated.toHttpResponse());
+            return null;
+        }, ctx.eventLoop());
+        return res;
+    }
+
+    private static void resolveException(CompletableFuture<HttpResponse> responseFuture, Throwable t) {
+        if (t instanceof UnprocessedRequestException) {
+            responseFuture.complete(HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE));
+            return;
+        }
+        responseFuture.completeExceptionally(t);
     }
 }

--- a/gateway/src/test/java/dev/gihwan/tollgate/gateway/UpstreamTest.java
+++ b/gateway/src/test/java/dev/gihwan/tollgate/gateway/UpstreamTest.java
@@ -51,7 +51,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import dev.gihwan.tollgate.junit5.GatewayExtension;
 import dev.gihwan.tollgate.testing.TestGateway;
 
-class DefaultUpstreamTest {
+class UpstreamTest {
 
     private static final AtomicReference<AggregatedHttpRequest> reqCapture = new AtomicReference<>();
 


### PR DESCRIPTION
Make `Upstream` as a kind of configuration class so that forward `HttpRequest`s in `UpstreamHttpService` instead of `Upstream`.
Remove forwarding logic from `Upstream`. It will manage settings of the upstream. Forwarding logic is moved to the `UpstreamHttpService`, but it's simple. Specific implementations such as exception mapping will be provided using SPI.
This is the last step of migration in #112.