### PR TITLE
Clean up builders

### DIFF
--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
@@ -50,7 +50,7 @@ public final class GatewayBuilder {
 
     private final ServerBuilder serverBuilder = Server.builder();
 
-    protected GatewayBuilder() {}
+    GatewayBuilder() {}
 
     /**
      * @see ServerBuilder#http(int)
@@ -152,7 +152,6 @@ public final class GatewayBuilder {
 
     /**
      * @see ServerBuilder#tls(PrivateKey, String, Iterable)
-     * @return
      */
     public GatewayBuilder tls(PrivateKey key,
                               @Nullable String keyPassword,
@@ -236,7 +235,7 @@ public final class GatewayBuilder {
         return route().path(pathPattern).decorators(decorators).build(upstream);
     }
 
-    public final Gateway build() {
+    public Gateway build() {
         return new Gateway(serverBuilder.build());
     }
 }

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBindingBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamBindingBuilder.java
@@ -259,7 +259,7 @@ public final class UpstreamBindingBuilder {
         return this;
     }
 
-    public final GatewayBuilder build(Upstream upstream) {
+    public GatewayBuilder build(Upstream upstream) {
         serviceBindingBuilder.build(new UpstreamHttpService(requireNonNull(upstream, "upstream")));
         return gatewayBuilder;
     }


### PR DESCRIPTION
Clean up `protected` constructor or `final` method in `final` class and missing javadoc tag description.