### PR TITLE
Introduce exception-mapping module

### DIFF
--- a/exception-mapping/build.gradle.kts
+++ b/exception-mapping/build.gradle.kts
@@ -22,27 +22,32 @@
  * SOFTWARE.
  */
 
-rootProject.name = "tollgate"
+import dev.gihwan.tollgate.Dependency
 
-include("gateway")
+plugins {
+    id("java-library")
+    id("dev.gihwan.tollgate.publish")
+}
 
-include("exception-mapping")
-include("hocon")
-include("junit5")
-include("remapping")
-include("standalone")
-include("testing")
-include("util")
+dependencies {
+    api(project(":gateway"))
+    implementation(project(":util"))
 
-include(":examples:helloworld")
-include(":examples:pokeapi:pokeapi-berry")
-include(":examples:pokeapi:pokeapi-contest")
-include(":examples:pokeapi:pokeapi-encounter")
-include(":examples:pokeapi:pokeapi-evolution")
-include(":examples:pokeapi:pokeapi-game")
-include(":examples:pokeapi:pokeapi-gateway")
-include(":examples:pokeapi:pokeapi-item")
-include(":examples:pokeapi:pokeapi-location")
-include(":examples:pokeapi:pokeapi-machine")
-include(":examples:pokeapi:pokeapi-move")
-include(":examples:pokeapi:pokeapi-pokemon")
+    implementation(Dependency.guava)
+    implementation(Dependency.slf4j)
+
+    testImplementation(project(":junit5"))
+    testImplementation(Dependency.assertj)
+
+    testRuntimeOnly(Dependency.junitEngine)
+    testRuntimeOnly(Dependency.logback)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/DefaultExceptionMappingFunction.java
+++ b/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/DefaultExceptionMappingFunction.java
@@ -22,27 +22,21 @@
  * SOFTWARE.
  */
 
-rootProject.name = "tollgate"
+package dev.gihwan.tollgate.exception.mapping;
 
-include("gateway")
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 
-include("exception-mapping")
-include("hocon")
-include("junit5")
-include("remapping")
-include("standalone")
-include("testing")
-include("util")
+enum DefaultExceptionMappingFunction implements ExceptionMappingFunction {
 
-include(":examples:helloworld")
-include(":examples:pokeapi:pokeapi-berry")
-include(":examples:pokeapi:pokeapi-contest")
-include(":examples:pokeapi:pokeapi-encounter")
-include(":examples:pokeapi:pokeapi-evolution")
-include(":examples:pokeapi:pokeapi-game")
-include(":examples:pokeapi:pokeapi-gateway")
-include(":examples:pokeapi:pokeapi-item")
-include(":examples:pokeapi:pokeapi-location")
-include(":examples:pokeapi:pokeapi-machine")
-include(":examples:pokeapi:pokeapi-move")
-include(":examples:pokeapi:pokeapi-pokemon")
+    INSTANCE;
+
+    @Override
+    public HttpResponse apply(Throwable cause) {
+        if (cause instanceof UnprocessedRequestException) {
+            return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+        }
+        return HttpResponse.ofFailure(cause);
+    }
+}

--- a/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingClient.java
+++ b/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingClient.java
@@ -1,0 +1,83 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.exception.mapping;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+
+/**
+ * A {@link HttpClient} decorator which maps a {@link Throwable} to a {@link HttpResponse}.
+ */
+public final class ExceptionMappingClient extends SimpleDecoratingHttpClient {
+
+    /**
+     * Returns a new {@link HttpClient} decorator which maps a {@link Throwable} to a {@link HttpResponse}
+     * using the default {@link ExceptionMappingFunction}.
+     */
+    public static Function<? super HttpClient, ExceptionMappingClient> newDecorator() {
+        return newDecorator(ExceptionMappingFunction.ofDefault());
+    }
+
+    /**
+     * Returns a new {@link HttpClient} decorator which maps a {@link Throwable} to a {@link HttpResponse}
+     * using the given {@link ExceptionMappingFunction}.
+     */
+    public static Function<? super HttpClient, ExceptionMappingClient> newDecorator(
+            ExceptionMappingFunction mappingFunction) {
+        requireNonNull(mappingFunction, "mappingFunction");
+        return delegate -> new ExceptionMappingClient(delegate, mappingFunction);
+    }
+
+    private final ExceptionMappingFunction mappingFunction;
+
+    ExceptionMappingClient(HttpClient delegate, ExceptionMappingFunction mappingFunction) {
+        super(delegate);
+        this.mappingFunction = mappingFunction;
+    }
+
+    @Override
+    public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+        final CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
+        final HttpResponse res = HttpResponse.from(resFuture);
+        unwrap().execute(ctx, req).aggregate().handleAsync((aggregated, cause) -> {
+            if (cause != null) {
+                resFuture.complete(mappingFunction.apply(cause));
+                return null;
+            }
+
+            resFuture.complete(aggregated.toHttpResponse());
+            return null;
+        }, ctx.eventLoop());
+        return res;
+    }
+}

--- a/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingFunction.java
+++ b/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingFunction.java
@@ -22,27 +22,28 @@
  * SOFTWARE.
  */
 
-rootProject.name = "tollgate"
+package dev.gihwan.tollgate.exception.mapping;
 
-include("gateway")
+import java.util.function.Function;
 
-include("exception-mapping")
-include("hocon")
-include("junit5")
-include("remapping")
-include("standalone")
-include("testing")
-include("util")
+import com.linecorp.armeria.common.HttpResponse;
 
-include(":examples:helloworld")
-include(":examples:pokeapi:pokeapi-berry")
-include(":examples:pokeapi:pokeapi-contest")
-include(":examples:pokeapi:pokeapi-encounter")
-include(":examples:pokeapi:pokeapi-evolution")
-include(":examples:pokeapi:pokeapi-game")
-include(":examples:pokeapi:pokeapi-gateway")
-include(":examples:pokeapi:pokeapi-item")
-include(":examples:pokeapi:pokeapi-location")
-include(":examples:pokeapi:pokeapi-machine")
-include(":examples:pokeapi:pokeapi-move")
-include(":examples:pokeapi:pokeapi-pokemon")
+/**
+ * A {@link Function} for mapping a {@link Throwable} to a {@link HttpResponse}.
+ */
+@FunctionalInterface
+public interface ExceptionMappingFunction extends Function<Throwable, HttpResponse> {
+
+    /**
+     * Returns the default implementation of {@link ExceptionMappingFunction}.
+     */
+    static ExceptionMappingFunction ofDefault() {
+        return DefaultExceptionMappingFunction.INSTANCE;
+    }
+
+    /**
+     * Maps the given {@link Throwable} to a {@link HttpResponse}.
+     */
+    @Override
+    HttpResponse apply(Throwable cause);
+}

--- a/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/package-info.java
+++ b/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/package-info.java
@@ -22,27 +22,7 @@
  * SOFTWARE.
  */
 
-rootProject.name = "tollgate"
+@NonNullByDefault
+package dev.gihwan.tollgate.exception.mapping;
 
-include("gateway")
-
-include("exception-mapping")
-include("hocon")
-include("junit5")
-include("remapping")
-include("standalone")
-include("testing")
-include("util")
-
-include(":examples:helloworld")
-include(":examples:pokeapi:pokeapi-berry")
-include(":examples:pokeapi:pokeapi-contest")
-include(":examples:pokeapi:pokeapi-encounter")
-include(":examples:pokeapi:pokeapi-evolution")
-include(":examples:pokeapi:pokeapi-game")
-include(":examples:pokeapi:pokeapi-gateway")
-include(":examples:pokeapi:pokeapi-item")
-include(":examples:pokeapi:pokeapi-location")
-include(":examples:pokeapi:pokeapi-machine")
-include(":examples:pokeapi:pokeapi-move")
-include(":examples:pokeapi:pokeapi-pokemon")
+import dev.gihwan.tollgate.util.NonNullByDefault;

--- a/exception-mapping/src/test/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingClientTest.java
+++ b/exception-mapping/src/test/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingClientTest.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.exception.mapping;
+
+import static dev.gihwan.tollgate.testing.TestGateway.withTestGateway;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+
+import dev.gihwan.tollgate.gateway.Upstream;
+import dev.gihwan.tollgate.testing.TestGateway;
+
+class ExceptionMappingClientTest {
+
+    @Test
+    void mapException() {
+        try (TestGateway gateway = withTestGateway(builder -> {
+            final int unusedPort;
+            try (ServerSocket ss = new ServerSocket(0)) {
+                unusedPort = ss.getLocalPort();
+            } catch (IOException e) {
+                fail(e.getMessage());
+                return;
+            }
+
+            builder.upstream("/refused", Upstream.builder("http", Endpoint.of("127.0.0.1", unusedPort))
+                                                 .decorator(ExceptionMappingClient.newDecorator())
+                                                 .build());
+        })) {
+            final WebClient webClient = WebClient.builder(gateway.httpUri()).build();
+
+            final AggregatedHttpResponse res = webClient.get("/refused").aggregate().join();
+            assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        }
+    }
+}

--- a/exception-mapping/src/test/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingFunctionTest.java
+++ b/exception-mapping/src/test/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingFunctionTest.java
@@ -22,27 +22,25 @@
  * SOFTWARE.
  */
 
-rootProject.name = "tollgate"
+package dev.gihwan.tollgate.exception.mapping;
 
-include("gateway")
+import static org.assertj.core.api.Assertions.assertThat;
 
-include("exception-mapping")
-include("hocon")
-include("junit5")
-include("remapping")
-include("standalone")
-include("testing")
-include("util")
+import org.junit.jupiter.api.Test;
 
-include(":examples:helloworld")
-include(":examples:pokeapi:pokeapi-berry")
-include(":examples:pokeapi:pokeapi-contest")
-include(":examples:pokeapi:pokeapi-encounter")
-include(":examples:pokeapi:pokeapi-evolution")
-include(":examples:pokeapi:pokeapi-game")
-include(":examples:pokeapi:pokeapi-gateway")
-include(":examples:pokeapi:pokeapi-item")
-include(":examples:pokeapi:pokeapi-location")
-include(":examples:pokeapi:pokeapi-machine")
-include(":examples:pokeapi:pokeapi-move")
-include(":examples:pokeapi:pokeapi-pokemon")
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+
+class ExceptionMappingFunctionTest {
+
+    @Test
+    void respondServiceUnavailableWhenUnProcessedRequestException() {
+        final ExceptionMappingFunction mappingFunction = ExceptionMappingFunction.ofDefault();
+
+        final HttpResponse res = mappingFunction.apply(UnprocessedRequestException.of(new RuntimeException()));
+        final AggregatedHttpResponse aggregatedRes = res.aggregate().join();
+        assertThat(aggregatedRes.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+}

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamHttpService.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/UpstreamHttpService.java
@@ -24,12 +24,8 @@
 
 package dev.gihwan.tollgate.gateway;
 
-import java.util.concurrent.CompletableFuture;
-
-import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -45,26 +41,7 @@ final class UpstreamHttpService implements HttpService {
     }
 
     @Override
-    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        final CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
-        final HttpResponse res = HttpResponse.from(resFuture);
-        upstream.client().execute(req).aggregate().handleAsync((aggregated, cause) -> {
-            if (cause != null) {
-                resolveException(resFuture, cause);
-                return null;
-            }
-
-            resFuture.complete(aggregated.toHttpResponse());
-            return null;
-        }, ctx.eventLoop());
-        return res;
-    }
-
-    private static void resolveException(CompletableFuture<HttpResponse> responseFuture, Throwable t) {
-        if (t instanceof UnprocessedRequestException) {
-            responseFuture.complete(HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE));
-            return;
-        }
-        responseFuture.completeExceptionally(t);
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
+        return upstream.client().execute(req);
     }
 }


### PR DESCRIPTION
Introduce `exception-mapping` module which provides the `ExceptionMappingClient` that maps a `Throwable` to a `HttpResponse`.
As exception handling is extracted from `UpstreamHttpService`, now gateway module is in charge of only forwarding `HttpRequest` to upstream.