### PR TITLE
Add option to configure logging requests and response using HOCON

### DIFF
--- a/examples/pokeapi/pokeapi-gateway/application.conf
+++ b/examples/pokeapi/pokeapi-gateway/application.conf
@@ -1,6 +1,11 @@
 tollgate {
   port = 8080
   healthCheckPath = "/health"
+  defaultLogging {
+    requestLogLevel = "INFO"
+    successfulResponseLogLevel = "INFO"
+    failureResponseLogLevel = "WARN"
+  }
 }
 
 include required(file("routing/berry.conf"))

--- a/examples/pokeapi/pokeapi-gateway/routing/berry.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/berry.conf
@@ -3,18 +3,24 @@ tollgate {
     getBerry {
       method = "GET"
       path = "/api/v2/berry/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "BerryLogger"
       upstream = ${tollgate.upstreams.berry}
       upstream.remapping.path = "/berry/{idOrName}"
     }
     getBerryFirmness {
       method = "GET"
       path = "/api/v2/berry-firmness/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "BerryLogger"
       upstream = ${tollgate.upstreams.berry}
       upstream.remapping.path = "/berry-firmness/{idOrName}"
     }
     getBerryFlavor {
       method = "GET"
       path = "/api/v2/berry-flavor/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "BerryLogger"
       upstream = ${tollgate.upstreams.berry}
       upstream.remapping.path = "/berry-flavor/{idOrName}"
     }
@@ -28,6 +34,8 @@ tollgate {
           port = 8080
         }
       ]
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "BerryLogger"
     }
   }
 }

--- a/examples/pokeapi/pokeapi-gateway/routing/contest.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/contest.conf
@@ -3,11 +3,15 @@ tollgate {
     getContestType {
       method = "GET"
       path = "/api/v2/contest-type/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "ContestLogger"
       upstream {
         uri = "http://contest:8080"
         remapping {
           path = "/contest-type/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "ContestLogger"
       }
     }
   }

--- a/examples/pokeapi/pokeapi-gateway/routing/encounter.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/encounter.conf
@@ -3,11 +3,15 @@ tollgate {
     getEncounterMethod {
       method = "GET"
       path = "/api/v2/encounter-method/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "EncounterLogger"
       upstream {
         uri = "http://encounter:8080"
         remapping {
           path = "/encounter-method/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "EncounterLogger"
       }
     }
   }

--- a/examples/pokeapi/pokeapi-gateway/routing/evolution.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/evolution.conf
@@ -3,11 +3,15 @@ tollgate {
     getEvolutionChain {
       method = "GET"
       path = "/api/v2/evolution-chain/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "EvolutionLogger"
       upstream {
         uri = "http://evolution:8080"
         remapping {
           path = "/evolution-chain/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "EvolutionLogger"
       }
     }
   }

--- a/examples/pokeapi/pokeapi-gateway/routing/game.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/game.conf
@@ -3,11 +3,15 @@ tollgate {
     getGeneration {
       method = "GET"
       path = "/api/v2/generation/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "GameLogger"
       upstream {
         uri = "http://game:8080"
         remapping {
           path = "/generation/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "GameLogger"
       }
     }
   }

--- a/examples/pokeapi/pokeapi-gateway/routing/item.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/item.conf
@@ -3,11 +3,15 @@ tollgate {
     getItem {
       method = "GET"
       path = "/api/v2/item/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "ItemLogger"
       upstream {
         uri = "http://item:8080"
         remapping {
           path = "/item/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "ItemLogger"
       }
     }
   }

--- a/examples/pokeapi/pokeapi-gateway/routing/location.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/location.conf
@@ -3,11 +3,15 @@ tollgate {
     getLocation {
       method = "GET"
       path = "/api/v2/location/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "LocationLogger"
       upstream {
         uri = "http://location:8080"
         remapping {
           path = "/location/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "LocationLogger"
       }
     }
   }

--- a/examples/pokeapi/pokeapi-gateway/routing/machine.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/machine.conf
@@ -3,11 +3,15 @@ tollgate {
     getMachine {
       method = "GET"
       path = "/api/v2/machine/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "MachineLogger"
       upstream {
         uri = "http://machine:8080"
         remapping {
           path = "/machine/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "MachineLogger"
       }
     }
   }

--- a/examples/pokeapi/pokeapi-gateway/routing/move.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/move.conf
@@ -3,11 +3,15 @@ tollgate {
     getMove {
       method = "GET"
       path = "/api/v2/move/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "MoveLogger"
       upstream {
         uri = "http://move:8080"
         remapping {
           path = "/move/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "MoveLogger"
       }
     }
   }

--- a/examples/pokeapi/pokeapi-gateway/routing/pokemon.conf
+++ b/examples/pokeapi/pokeapi-gateway/routing/pokemon.conf
@@ -3,11 +3,15 @@ tollgate {
     getAbility {
       method = "GET"
       path = "/api/v2/ability/{idOrName}"
+      logging = ${tollgate.defaultLogging}
+      logging.logger = "PokemonLogger"
       upstream {
         uri = "http://pokemon:8080"
         remapping {
           path = "/ability/{idOrName}"
         }
+        logging = ${tollgate.defaultLogging}
+        logging.logger = "PokemonLogger"
       }
     }
   }

--- a/hocon/README.md
+++ b/hocon/README.md
@@ -56,8 +56,20 @@ tollgate {
     getBerry {
       method = "GET"
       path = "/api/v2/berry/{idOrName}"
+      logging {
+        logger = "BerryLogger"
+        requestLogLevel = "INFO"
+        successfulResponseLogLevel = "INFO"
+        failureResponseLogLevel = "WARN"
+      }
       upstream {
         uri = "http://berry:8080"
+        logging {
+          logger = "BerryLogger"
+          requestLogLevel = "INFO"
+          successfulResponseLogLevel = "INFO"
+          failureResponseLogLevel = "WARN"
+        }
       }
     }
   }
@@ -70,6 +82,7 @@ tollgate {
 |------|------|-----------|-------------|------|
 | `method` | `string` | `required` | HTTP method which this endpoint expose as | |
 | `path` | `string` | `required` | URI path which this endpoint expose to | |
+| `logging` | `object` | `optional` | A [Logging Configuration](#logging-configuration) to log requests and responses from this endpoint | |
 | `upstream` | `object` | `required` | A [Upstream Configuration](#upstream-configuration) to proxy requests from this endpoint | |
 
 ### Upstream Configuration
@@ -80,6 +93,7 @@ tollgate {
 | `scheme` | `string` | `optional` | A scheme of an URI of the upstream | |
 | `endpoints` | `list` | `optional` | A list of [Endpoint Configuration](#endpoint-configuration) of an URI of the upstream | |
 | `remapping` | `object` | `optional` | A [Remapping Upstream Configuration](#remapping-upstream-configuration) to remap request or response | |
+| `logging` | `object` | `optional` | A [Logging Configuration](#logging-configuration) to log requests and responses to the upstream | |
 
 > **Note** One of `uri` or `scheme` and `endpoints` pair MUST be required.
 
@@ -95,3 +109,15 @@ tollgate {
 | Name | Type | Mandatory | Description | Note |
 |------|------|-----------|-------------|------|
 | `path` | `string` | `optional` | Remaps request path | |
+
+### Logging Configuration
+
+| Name | Type | Mandatory | Description | Note |
+|------|------|-----------|-------------|------|
+| `logger` | `string` | `optional` | Name to use when logging. | |
+| `requestLogLevel` | `string` | `optional` | `LogLevel` to use when logging requests. | If unset, will use `DEBUG`. |
+| `successfulResponseLogLevel` | `string` | `optional` | `LogLevel` to use when logging successful responses (e.g., no unhandled exception). | If unset, will use `DEBUG`. |
+| `failureResponseLogLevel` | `string` | `optional` | `LogLevel` to use when logging failure responses (e.g., failed with an exception). | It unset, will use `WARN`. |
+| `samplingRate` | `double` | `optional` | Rate to sample requests to log. | |
+
+> **Note** The `LogLevel` should be one of `OFF`, `TRACE`, `DEBUG`, `INFO`, `WARN` and `ERROR`.

--- a/hocon/build.gradle.kts
+++ b/hocon/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     testImplementation(Dependency.armeriaJunit)
 
     testRuntimeOnly(Dependency.junitEngine)
+    testRuntimeOnly(Dependency.logback)
 }
 
 java {

--- a/hocon/src/test/resources/application-logging.conf
+++ b/hocon/src/test/resources/application-logging.conf
@@ -1,0 +1,24 @@
+tollgate {
+  port = 0
+  healthCheckPath = "/health"
+  routing {
+    foo {
+      method = "GET"
+      path = "/foo"
+      logging {
+        logger = "dev.gihwan.tollgate.gateway.FooLogger"
+        requestLogLevel = "INFO"
+        successfulResponseLogLevel = "INFO"
+        failureResponseLogLevel = "WARN"
+      }
+      upstream {
+        logging {
+          logger = "dev.gihwan.tollgate.gateway.FooLogger"
+          requestLogLevel = "INFO"
+          successfulResponseLogLevel = "INFO"
+          failureResponseLogLevel = "WARN"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a `logging` option to HOCON for configuring logging requests and response.
Configure `logging` to `routing` configuration to log requests and responses from the specified endpoint. Similarly, configure to `upstream` configuration to the specified upstream.
The `logging` configuration has options:
 - `logger`: Name to use when logging
 - `requestLogLevel`: `LogLevel` to use when logging requests.
 - `successfulResponseLogLevel`: `LogLevel` to use when logging successful responses (e.g., no unhandled exception).
 - `failureResponseLogLevel`: `LogLevel` to use when logging failure responses (e.g., failed with an exception).
 - `samplingRate`: Rate to sample requests to log.

Please read `hocon/README.md` for more information.