### PR TITLE
Fix README in remapping module

### DIFF
--- a/remapping/README.md
+++ b/remapping/README.md
@@ -1,22 +1,22 @@
 # remapping
 
-A `Upstream` decorator to remap `HttpRequest` or `HttpResponse`.
+A `HttpClient` decorator which remaps `HttpRequest` or `HttpResponse`.
 
 ## Getting Started
 
-It provides `RemappingUpstream`, `RemappingRequestStrategy` and `RemappingResponseStrategy`:
+It provides `RemappingClient`, `RemappingRequestStrategy` and `RemappingResponseStrategy`:
 
 ```java
 Upstream.of("http://10.0.1.1")
-        .decorate(RemappingUpstream.newDecorator(
+        .decorate(RemappingClient.newDecorator(
             new RemappingRequestStrategy() {
                 @Override
-                public HttpRequest remap(ServiceRequestContext ctx, HttpRequest req) {
+                public HttpRequest remap(ClientRequestContext ctx, HttpRequest req) {
                     ... // remaps HTTP request to upstream server
                 }
             }, new RemappingResponseStrategy() {
-                @Override 
-                public HttpResponse remap(ServiceRequestContext ctx, HttpResponse res) {
+                @Override
+                public HttpResponse remap(ClientRequestContext ctx, HttpResponse res) {
                     ... // remaps HTTP response from upstream server
                 }
             }));
@@ -26,27 +26,27 @@ Or you can use builder:
 
 ```java
 Upstream.of("http://10.0.1.1")
-        .decorate(RemappingUpstream.builder()
-                                   .requestStrategy(new RemappingRequestStrategy() {
-                                       @Override
-                                       public HttpRequest remap(ServiceRequestContext ctx, HttpRequest req) {
-                                           ... // remaps HTTP request to upstream server
-                                       }
-                                   })
-                                   .responseStrategy(new RemappingResponseStrategy() {
-                                       @Override
-                                       public HttpResponse remap(ServiceRequestContext ctx, HttpResponse res) {
-                                           ... // remaps HTTP response from upstream server
-                                       }
-                                   })
-                                   .newDecorator());
+        .decorate(RemappingClient.builder()
+                                 .requestStrategy(new RemappingRequestStrategy() {
+                                     @Override
+                                     public HttpRequest remap(ClientRequestContext ctx, HttpRequest req) {
+                                         ... // remaps HTTP request to upstream server
+                                     }
+                                 })
+                                 .responseStrategy(new RemappingResponseStrategy() {
+                                     @Override
+                                     public HttpResponse remap(ClientRequestContext ctx, HttpResponse res) {
+                                         ... // remaps HTTP response from upstream server
+                                     }
+                                 })
+                                 .newDecorator());
 ```
 
 It also provides useful implementation:
 
 ```java
 Upstream.of("http://10.0.1.1")
-        .decorate(RemappingUpstream.builder()
-                                   .requestPath("/foo/{bar}") // automatically remaps URI path to `/foo/{bar}`, `bar` is path parameter
-                                   .newDecorator());
+        .decorate(RemappingClient.builder()
+                                 .requestPath("/foo/{bar}") // automatically remaps URI path to `/foo/{bar}`, `bar` is path parameter
+                                 .newDecorator());
 ```


### PR DESCRIPTION
Fix outdated `README.md` in `remapping` module, change `RemappingUpstream` to `RemappingClient`.