### PR TITLE
Configure `Server` using configurator instead of delegating builder

### DIFF
--- a/examples/helloworld/src/main/java/dev/gihwan/tollgate/example/helloworld/HelloWorldGateway.java
+++ b/examples/helloworld/src/main/java/dev/gihwan/tollgate/example/helloworld/HelloWorldGateway.java
@@ -43,7 +43,7 @@ public final class HelloWorldGateway {
 
     public static void main(String[] args) {
         final Gateway gateway = Gateway.builder()
-                                       .http(8080)
+                                       .server(builder -> builder.http(8080))
                                        .upstream("/helloworld", Upstream.of("http://localhost:9090"))
                                        .build();
 

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/GatewayBuilder.java
@@ -26,16 +26,8 @@ package dev.gihwan.tollgate.gateway;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
-import java.io.InputStream;
-import java.net.InetSocketAddress;
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
-import javax.annotation.Nullable;
-import javax.net.ssl.KeyManagerFactory;
 
 import com.google.common.collect.ImmutableList;
 
@@ -44,8 +36,6 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 
-import io.netty.handler.ssl.SslContextBuilder;
-
 public final class GatewayBuilder {
 
     private final ServerBuilder serverBuilder = Server.builder();
@@ -53,144 +43,14 @@ public final class GatewayBuilder {
     GatewayBuilder() {}
 
     /**
-     * @see ServerBuilder#http(int)
+     * Configures a {@link Server} of a {@link Gateway} with the given {@code configurator}.
+     *
+     * Please note that calling {@link ServerBuilder#build()} inside {@code configurator} does not affect
+     * building {@link Gateway}.
      */
-    public GatewayBuilder http(int port) {
-        serverBuilder.http(port);
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#http(InetSocketAddress)
-     */
-    public GatewayBuilder http(InetSocketAddress localAddress) {
-        serverBuilder.http(requireNonNull(localAddress, "localAddress"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#https(int)
-     */
-    public GatewayBuilder https(int port) {
-        serverBuilder.https(port);
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#https(InetSocketAddress)
-     */
-    public GatewayBuilder https(InetSocketAddress localAddress) {
-        serverBuilder.https(requireNonNull(localAddress, "localAddress"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(File, File)
-     */
-    public GatewayBuilder tls(File keyCertChainFile, File keyFile) {
-        serverBuilder.tls(requireNonNull(keyCertChainFile, "keyCertChainFile"),
-                          requireNonNull(keyFile, "keyFile"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(File, File, String)
-     */
-    public GatewayBuilder tls(File keyCertChainFile, File keyFile, @Nullable String keyPassword) {
-        serverBuilder.tls(requireNonNull(keyCertChainFile, "keyCertChainFile"),
-                          requireNonNull(keyFile, "keyFile"),
-                          keyPassword);
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(InputStream, InputStream)
-     */
-    public GatewayBuilder tls(InputStream keyCertChainInputStream, InputStream keyInputStream) {
-        serverBuilder.tls(requireNonNull(keyCertChainInputStream, "keyCertChainInputStream"),
-                          requireNonNull(keyInputStream, "keyInputStream"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(InputStream, InputStream, String)
-     */
-    public GatewayBuilder tls(InputStream keyCertChainInputStream,
-                              InputStream keyInputStream,
-                              @Nullable String keyPassword) {
-        serverBuilder.tls(requireNonNull(keyCertChainInputStream, "keyCertChainInputStream"),
-                          requireNonNull(keyInputStream, "keyInputStream"),
-                          keyPassword);
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(PrivateKey, X509Certificate...)
-     */
-    public GatewayBuilder tls(PrivateKey key, X509Certificate... keyCertChain) {
-        serverBuilder.tls(requireNonNull(key, "key"), requireNonNull(keyCertChain, "keyCertChain"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(PrivateKey, Iterable)
-     */
-    public GatewayBuilder tls(PrivateKey key, Iterable<? extends X509Certificate> keyCertChain) {
-        serverBuilder.tls(requireNonNull(key, "key"), requireNonNull(keyCertChain, "keyCertChain"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(PrivateKey, String, X509Certificate...)
-     */
-    public GatewayBuilder tls(PrivateKey key, @Nullable String keyPassword, X509Certificate... keyCertChain) {
-        serverBuilder.tls(requireNonNull(key, "key"),
-                          keyPassword,
-                          requireNonNull(keyCertChain, "keyCertChain"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(PrivateKey, String, Iterable)
-     */
-    public GatewayBuilder tls(PrivateKey key,
-                              @Nullable String keyPassword,
-                              Iterable<? extends X509Certificate> keyCertChain) {
-        serverBuilder.tls(requireNonNull(key, "key"),
-                          keyPassword,
-                          requireNonNull(keyCertChain, "keyCertChain"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tls(KeyManagerFactory)
-     */
-    public GatewayBuilder tls(KeyManagerFactory keyManagerFactory) {
-        serverBuilder.tls(requireNonNull(keyManagerFactory, "keyManagerFactory"));
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tlsSelfSigned()
-     */
-    public GatewayBuilder tlsSelfSigned() {
-        serverBuilder.tlsSelfSigned();
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tlsSelfSigned(boolean)
-     */
-    public GatewayBuilder tlsSelfSigned(boolean tlsSelfSigned) {
-        serverBuilder.tlsSelfSigned(tlsSelfSigned);
-        return this;
-    }
-
-    /**
-     * @see ServerBuilder#tlsCustomizer(Consumer)
-     */
-    public GatewayBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
-        serverBuilder.tlsCustomizer(requireNonNull(tlsCustomizer, "tlsCustomizer"));
+    public GatewayBuilder server(Consumer<? super ServerBuilder> configurator) {
+        requireNonNull(configurator, "configurator");
+        configurator.accept(serverBuilder);
         return this;
     }
 

--- a/gateway/src/test/java/dev/gihwan/tollgate/gateway/GatewayTest.java
+++ b/gateway/src/test/java/dev/gihwan/tollgate/gateway/GatewayTest.java
@@ -52,7 +52,7 @@ class GatewayTest {
     @Test
     void http() {
         final Gateway gateway = Gateway.builder()
-                                       .http(0)
+                                       .server(builder -> builder.http(0))
                                        .upstream("/foo", Upstream.of(serviceServer.httpUri()))
                                        .build();
         gateway.start().join();
@@ -70,8 +70,7 @@ class GatewayTest {
     @Test
     void https() {
         final Gateway gateway = Gateway.builder()
-                                       .https(0)
-                                       .tlsSelfSigned()
+                                       .server(builder -> builder.https(0).tlsSelfSigned())
                                        .upstream("/foo", Upstream.of(serviceServer.httpUri()))
                                        .build();
         gateway.start().join();

--- a/hocon/src/main/java/dev/gihwan/tollgate/hocon/DefaultHoconGatewayConfigurator.java
+++ b/hocon/src/main/java/dev/gihwan/tollgate/hocon/DefaultHoconGatewayConfigurator.java
@@ -61,7 +61,8 @@ enum DefaultHoconGatewayConfigurator implements HoconGatewayConfigurator {
         requireNonNull(config, "config");
 
         if (config.hasPath("tollgate.port")) {
-            builder.http(config.getInt("tollgate.port"));
+            final int port = config.getInt("tollgate.port");
+            builder.server(serverBuilder -> serverBuilder.http(port));
         }
         if (config.hasPath("tollgate.healthCheckPath")) {
             builder.healthCheck(config.getString("tollgate.healthCheckPath"));

--- a/junit5/src/test/java/dev/gihwan/tollgate/junit5/GatewayExtensionTest.java
+++ b/junit5/src/test/java/dev/gihwan/tollgate/junit5/GatewayExtensionTest.java
@@ -41,8 +41,8 @@ class GatewayExtensionTest {
     static GatewayExtension gateway = new GatewayExtension() {
         @Override
         public void configure(GatewayBuilder builder) {
-            builder.http(0);
-            builder.https(0).tlsSelfSigned();
+            builder.server(serverBuilder -> serverBuilder.http(0)
+                                                         .https(0).tlsSelfSigned());
             builder.healthCheck("/health");
         }
     };

--- a/testing/src/test/java/dev/gihwan/tollgate/testing/TestGatewayTest.java
+++ b/testing/src/test/java/dev/gihwan/tollgate/testing/TestGatewayTest.java
@@ -40,8 +40,8 @@ class TestGatewayTest {
     @Test
     void port() {
         try (TestGateway gateway = withTestGateway(builder -> {
-            builder.http(0);
-            builder.https(0).tlsSelfSigned();
+            builder.server(serverBuilder -> serverBuilder.http(0)
+                                                         .https(0).tlsSelfSigned());
             builder.upstream("/foo", Upstream.of("http://127.0.0.1"));
         })) {
             assertThat(gateway.httpPort()).isPositive();
@@ -52,8 +52,8 @@ class TestGatewayTest {
     @Test
     void uri() {
         try (TestGateway gateway = withTestGateway(builder -> {
-            builder.http(0);
-            builder.https(0).tlsSelfSigned();
+            builder.server(serverBuilder -> serverBuilder.http(0)
+                                                         .https(0).tlsSelfSigned());
             builder.upstream("/foo", Upstream.of("http://127.0.0.1"));
         })) {
             assertThat(gateway.httpUri()).isNotNull();


### PR DESCRIPTION
In `GatewayBuilder`, configure `Server` using a configurator, `Consumer` with `ServerBuilder`, instead of delegating `ServerBuilder`.
If keep delegating, `GatewayBuilder` should delegate all methods following Armeria changes. Instead of it, provide a way to configure the `Server` using `ServerBuilder` directly. Then users can configure the 'Server' as much as they want.
It breaks `GatewayBuilder`, some delegated methods (`http`, `https`, `tls` and `tlsSelfSigned`) are removed.