### PR TITLE
Upgrade dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@
  */
 
 plugins {
-    id("com.google.cloud.tools.jib") version "2.7.0" apply false
+    id("com.google.cloud.tools.jib") version "3.1.2" apply false
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
+++ b/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
@@ -25,17 +25,17 @@
 package dev.gihwan.tollgate
 
 object Version {
-    const val armeria = "1.5.0"
+    const val armeria = "1.9.2"
 
-    const val commonsLang3 = "3.11"
+    const val commonsLang3 = "3.12.0"
     const val config = "1.4.1"
-    const val guava = "30.1-jre"
+    const val guava = "30.1.1-jre"
     const val jsr305 = "3.0.2"
     const val logback = "1.2.3"
-    const val slf4j = "1.7.30"
+    const val slf4j = "1.7.31"
 
-    const val assertj = "3.19.0"
-    const val awaitility = "4.0.3"
-    const val junit = "5.7.1"
-    const val mockito = "3.7.7"
+    const val assertj = "3.20.2"
+    const val awaitility = "4.1.0"
+    const val junit = "5.7.2"
+    const val mockito = "3.11.2"
 }


### PR DESCRIPTION
Bump `armeria` from `1.5.0` to `1.9.2`.
Bump `commons-lang3` from `3.11` to `3.12.0`.
Bump `guava` from `30.1-jre` to `30.1.1-jre`.
Bump `slf4j` from `1.7.30` to `1.7.31`.
Bump `assertj` from `3.19.0` to `3.20.2`.
Bump `awaitility` from `4.0.3` to `4.1.0`.
Bump `junit` from `5.7.1` to `5.7.2`.
Bump `mockito` from `3.7.7` to `3.11.2`.
Bump `jib-gradle-plugin` from `2.7.0` to `3.1.2`.