### PR TITLE
Remove JCenter from Gradle repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,5 @@ allprojects {
 
     repositories {
         mavenCentral()
-        jcenter()
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {


### PR DESCRIPTION
Remove JCenter because JFrog shut down: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/