### PR TITLE
Fix artifact id doesn't have middle name

### DIFF
--- a/buildSrc/src/main/kotlin/dev/gihwan/tollgate/PublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/dev/gihwan/tollgate/PublishPlugin.kt
@@ -50,7 +50,7 @@ class PublishPlugin : Plugin<Project> {
         val mavenPublication = publishing.publications.create("maven", MavenPublication::class.java)
         project.afterEvaluate {
             mavenPublication.groupId = group.toString()
-            mavenPublication.artifactId = "tollgate-${name}"
+            mavenPublication.artifactId = artifactId
             mavenPublication.version = version.toString()
 
             project.plugins.withType(JavaPlugin::class.java).all {
@@ -62,4 +62,7 @@ class PublishPlugin : Plugin<Project> {
             }
         }
     }
+
+    private val Project.artifactId: String
+        get() = parent?.let { "${it.artifactId}-${name}" } ?: name
 }


### PR DESCRIPTION
Fix publish plugin does not concern parent's name. It was ok until now because any module doesn't have middle module. However, `spring-boot2-autoconfigure` and `spring-boot2-starter` now have the middle module `spring`.

This commit makes the publish plugin set artifact id considering parent recursively. The `tollgate-boot2-autoconfigure` (`starter`) is fixed to `tollgate-spring-boot2-autoconfigure` (`starter`).

We don't need `tollgate` prefix anymore since the root project is `tollgate`.