### PR TITLE
Build pull request on both JDK 11 and 16

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,15 +7,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ "11", "16" ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
       - name: Build using Gradle
         run: gradle build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java-version }}
       - name: Build using Gradle

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,13 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ "11", "16" ]
+        java-version: [ 11, 16 ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
+          distribution: temurin
           java-version: ${{ matrix.java-version }}
       - name: Build using Gradle
         run: gradle build

--- a/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Dependency.kt
+++ b/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Dependency.kt
@@ -28,6 +28,8 @@ object Dependency {
     const val armeria = "com.linecorp.armeria:armeria:${Version.armeria}"
     const val armeriaJunit = "com.linecorp.armeria:armeria-junit5:${Version.armeria}"
 
+    const val bcpkix = "org.bouncycastle:bcpkix-jdk15on:${Version.bouncycastle}"
+    const val bcprov = "org.bouncycastle:bcprov-jdk15on:${Version.bouncycastle}"
     const val commonsLang3 = "org.apache.commons:commons-lang3:${Version.commonsLang3}"
     const val config = "com.typesafe:config:${Version.config}"
     const val guava = "com.google.guava:guava:${Version.guava}"

--- a/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
+++ b/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
@@ -27,6 +27,7 @@ package dev.gihwan.tollgate
 object Version {
     const val armeria = "1.9.2"
 
+    const val bouncycastle = "1.69"
     const val commonsLang3 = "3.12.0"
     const val config = "1.4.1"
     const val guava = "30.1.1-jre"

--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation(project(":util"))
 
     api(Dependency.armeria)
+    implementation(Dependency.bcpkix)
+    implementation(Dependency.bcprov)
     implementation(Dependency.commonsLang3)
     implementation(Dependency.guava)
     implementation(Dependency.jsr305)


### PR DESCRIPTION
tollgate requires Java 11 or newer. However, GitHub Actions build only on JDK 11 so we can't check it's available on JDK 12 or newer. Now the GitHub Actions build on both JDK 11 and 16. When JDK 17 that is the latest LTS version is released, will change JDK 16 to 17.