### PR TITLE
Upgrade dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@
  */
 
 plugins {
-    id("com.google.cloud.tools.jib") version "3.1.2" apply false
+    id("com.google.cloud.tools.jib") version "3.1.4" apply false
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
+++ b/buildSrc/src/main/kotlin/dev/gihwan/tollgate/Version.kt
@@ -25,19 +25,19 @@
 package dev.gihwan.tollgate
 
 object Version {
-    const val armeria = "1.9.2"
+    const val armeria = "1.11.0"
 
     const val bouncycastle = "1.69"
     const val commonsLang3 = "3.12.0"
     const val config = "1.4.1"
     const val guava = "30.1.1-jre"
     const val jsr305 = "3.0.2"
-    const val logback = "1.2.3"
-    const val slf4j = "1.7.31"
+    const val logback = "1.2.5"
+    const val slf4j = "1.7.32"
     const val springBoot = "2.5.4"
 
     const val assertj = "3.20.2"
     const val awaitility = "4.1.0"
     const val junit = "5.7.2"
-    const val mockito = "3.11.2"
+    const val mockito = "3.12.4"
 }


### PR DESCRIPTION
Bump `armeria` from `1.9.2` to `1.11.0`.
Bump `logback` from `1.2.3` to `1.2.5`.
Bump `slf4j` from `1.7.31` to `1.7.32`.
Bump `mockito` from `3.11.2` to `3.11.4`.
Bump `jib-gradle-plugin` from `3.1.2` to `3.1.4`.