### PR TITLE
Allow to transform `HttpRequest` or `HttpResponse`

### DIFF
--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/DisallowRequestHeadersFunction.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/DisallowRequestHeadersFunction.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.gateway;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
+
+import io.netty.util.AsciiString;
+
+final class DisallowRequestHeadersFunction implements Function<HttpRequest, HttpRequest> {
+
+    static DisallowRequestHeadersFunction ofSet(Set<AsciiString> disallowedRequestHeaders) {
+        checkArgument(!disallowedRequestHeaders.isEmpty(), "disallowed request headers should not be empty");
+        return new DisallowRequestHeadersFunction((name, value) -> disallowedRequestHeaders.contains(name));
+    }
+
+    private final BiPredicate<AsciiString, String> predicate;
+
+    private DisallowRequestHeadersFunction(BiPredicate<AsciiString, String> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public HttpRequest apply(HttpRequest req) {
+        return req.mapHeaders(this::disallowRequestHeaders);
+    }
+
+    private RequestHeaders disallowRequestHeaders(RequestHeaders headers) {
+        final RequestHeadersBuilder builder = headers.toBuilder();
+        headers.forEach((name, value) -> {
+            if (predicate.test(name, value)) {
+                builder.remove(name);
+            }
+        });
+        return builder.build();
+    }
+}

--- a/gateway/src/main/java/dev/gihwan/tollgate/gateway/DisallowResponseHeadersFunction.java
+++ b/gateway/src/main/java/dev/gihwan/tollgate/gateway/DisallowResponseHeadersFunction.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.gateway;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.ResponseHeadersBuilder;
+
+import io.netty.util.AsciiString;
+
+final class DisallowResponseHeadersFunction implements Function<HttpResponse, HttpResponse> {
+
+    static DisallowResponseHeadersFunction ofSet(Set<AsciiString> disallowedResponseHeaders) {
+        checkArgument(!disallowedResponseHeaders.isEmpty(), "disallowed response headers should not be empty");
+        return new DisallowResponseHeadersFunction((name, value) -> disallowedResponseHeaders.contains(name));
+    }
+
+    private final BiPredicate<AsciiString, String> predicate;
+
+    private DisallowResponseHeadersFunction(BiPredicate<AsciiString, String> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public HttpResponse apply(HttpResponse res) {
+        return res.mapHeaders(this::disallowResponseHeaders);
+    }
+
+    private ResponseHeaders disallowResponseHeaders(ResponseHeaders headers) {
+        final ResponseHeadersBuilder builder = headers.toBuilder();
+        headers.forEach((name, value) -> {
+            if (predicate.test(name, value)) {
+                builder.remove(name);
+            }
+        });
+        return builder.build();
+    }
+}

--- a/gateway/src/test/java/dev/gihwan/tollgate/gateway/DisallowRequestHeadersFunctionTest.java
+++ b/gateway/src/test/java/dev/gihwan/tollgate/gateway/DisallowRequestHeadersFunctionTest.java
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestHeaders;
+
+class DisallowRequestHeadersFunctionTest {
+    @Test
+    void ofSetShouldDisallowSpecifiedRequestHeaders() {
+        final DisallowRequestHeadersFunction function =
+                DisallowRequestHeadersFunction.ofSet(Set.of(HttpHeaderNames.of("foo")));
+
+        final HttpRequest req = HttpRequest.of(RequestHeaders.builder(HttpMethod.GET, "/")
+                                                             .add("foo", "this is foo")
+                                                             .add("bar", "this is bar")
+                                                             .add("baz", "this is baz")
+                                                             .build());
+        final HttpRequest applied = function.apply(req);
+        final RequestHeaders headers = applied.headers();
+        assertThat(headers.get("foo")).isNull();
+        assertThat(headers.get("bar")).isEqualTo("this is bar");
+        assertThat(headers.get("baz")).isEqualTo("this is baz");
+    }
+
+    @Test
+    void ofSetShouldDisallowSpecifiedRequestHeadersWithMultiValues() {
+        final DisallowRequestHeadersFunction function =
+                DisallowRequestHeadersFunction.ofSet(Set.of(HttpHeaderNames.of("foo")));
+
+        final HttpRequest req = HttpRequest.of(RequestHeaders.builder(HttpMethod.GET, "/")
+                                                             .add("foo", "this is first foo")
+                                                             .add("foo", "this is second foo")
+                                                             .add("bar", "this is first bar")
+                                                             .add("bar", "this is second bar")
+                                                             .add("baz", "this is first baz")
+                                                             .add("baz", "this is second baz")
+                                                             .build());
+        final HttpRequest applied = function.apply(req);
+        final RequestHeaders headers = applied.headers();
+        assertThat(headers.getAll("foo")).isEmpty();
+        assertThat(headers.getAll("bar")).containsExactlyInAnyOrder("this is first bar", "this is second bar");
+        assertThat(headers.getAll("baz")).containsExactlyInAnyOrder("this is first baz", "this is second baz");
+    }
+
+    @Test
+    void ofSetShouldDisallowAllSpecifiedRequestHeaders() {
+        final DisallowRequestHeadersFunction function =
+                DisallowRequestHeadersFunction.ofSet(Set.of(HttpHeaderNames.of("foo"),
+                                                            HttpHeaderNames.of("bar")));
+
+        final HttpRequest req = HttpRequest.of(RequestHeaders.builder(HttpMethod.GET, "/")
+                                                             .add("foo", "this is foo")
+                                                             .add("bar", "this is bar")
+                                                             .add("baz", "this is baz")
+                                                             .build());
+        final HttpRequest applied = function.apply(req);
+        final RequestHeaders headers = applied.headers();
+        assertThat(headers.get("foo")).isNull();
+        assertThat(headers.get("bar")).isNull();
+        assertThat(headers.get("baz")).isEqualTo("this is baz");
+    }
+}

--- a/gateway/src/test/java/dev/gihwan/tollgate/gateway/DisallowResponseHeadersFunctionTest.java
+++ b/gateway/src/test/java/dev/gihwan/tollgate/gateway/DisallowResponseHeadersFunctionTest.java
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 - 2021 Gihwan Kim
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.gihwan.tollgate.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+
+class DisallowResponseHeadersFunctionTest {
+    @Test
+    void ofSetShouldDisallowSpecifiedResponseHeaders() {
+        final DisallowResponseHeadersFunction function =
+                DisallowResponseHeadersFunction.ofSet(Set.of(HttpHeaderNames.of("foo")));
+
+        final HttpResponse res = HttpResponse.of(ResponseHeaders.builder(HttpStatus.OK)
+                                                                .add("foo", "this is foo")
+                                                                .add("bar", "this is bar")
+                                                                .add("baz", "this is baz")
+                                                                .build());
+        final AggregatedHttpResponse applied = function.apply(res).aggregate().join();
+        final ResponseHeaders headers = applied.headers();
+        assertThat(headers.get("foo")).isNull();
+        assertThat(headers.get("bar")).isEqualTo("this is bar");
+        assertThat(headers.get("baz")).isEqualTo("this is baz");
+    }
+
+    @Test
+    void ofSetShouldDisallowSpecifiedResponseHeadersWithMultiValues() {
+        final DisallowResponseHeadersFunction function =
+                DisallowResponseHeadersFunction.ofSet(Set.of(HttpHeaderNames.of("foo")));
+
+        final HttpResponse res = HttpResponse.of(ResponseHeaders.builder(HttpStatus.OK)
+                                                                .add("foo", "this is first foo")
+                                                                .add("foo", "this is second foo")
+                                                                .add("bar", "this is first bar")
+                                                                .add("bar", "this is second bar")
+                                                                .add("baz", "this is first baz")
+                                                                .add("baz", "this is second baz")
+                                                                .build());
+        final AggregatedHttpResponse applied = function.apply(res).aggregate().join();
+        final ResponseHeaders headers = applied.headers();
+        assertThat(headers.getAll("foo")).isEmpty();
+        assertThat(headers.getAll("bar")).containsExactlyInAnyOrder("this is first bar", "this is second bar");
+        assertThat(headers.getAll("baz")).containsExactlyInAnyOrder("this is first baz", "this is second baz");
+    }
+
+    @Test
+    void ofSetShouldDisallowAllSpecifiedResponseHeaders() {
+        final DisallowResponseHeadersFunction function =
+                DisallowResponseHeadersFunction.ofSet(Set.of(HttpHeaderNames.of("foo"),
+                                                             HttpHeaderNames.of("bar")));
+
+        final HttpResponse res = HttpResponse.of(ResponseHeaders.builder(HttpStatus.OK)
+                                                                .add("foo", "this is foo")
+                                                                .add("bar", "this is bar")
+                                                                .add("baz", "this is baz")
+                                                                .build());
+        final AggregatedHttpResponse applied = function.apply(res).aggregate().join();
+        final ResponseHeaders headers = applied.headers();
+        assertThat(headers.get("foo")).isNull();
+        assertThat(headers.get("bar")).isNull();
+        assertThat(headers.get("baz")).isEqualTo("this is baz");
+    }
+}


### PR DESCRIPTION
Add `mapRequest` and `mapResponse` methods to `UpstreamBuilder`. They allow users to transform `HttpRequest` or `HttpResponse` directly. It would be useful if a user want to customize something that Tollgate doesn't support yet.

Existing `disallowRequestHeaders` and `disallowResponseHeaders` now uses `mapRequest` and `mapResponse` respectively. Implementation of disallow is extracted from `DefaultUpstream` to independent `Function` implementation, `DisallowRequestHeadersFunction` and `DisallowResponseHeadersFunction`. Because both functions accept `Predicate` to test which headers to disallow, we can provide more easier way to disallow headers in future.