### PR TITLE
Deprecate `exception-mapping` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gateway.start().join();
 
 ## Features
 
-- [exception-mapping](/exception-mapping)
+- [exception-mapping](/exception-mapping) (deprecated)
     - Maps a `Throwable` which is thrown while forwarding to an appropriate `HttpResponse`.
 - [HOCON](/hocon)
     - Builds `Gateway` using a HOCON (Human-Optimized Config Object Notation) configuration.

--- a/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/DefaultExceptionMappingFunction.java
+++ b/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/DefaultExceptionMappingFunction.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 
+@Deprecated(forRemoval = true)
 enum DefaultExceptionMappingFunction implements ExceptionMappingFunction {
 
     INSTANCE;

--- a/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingClient.java
+++ b/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingClient.java
@@ -38,12 +38,14 @@ import com.linecorp.armeria.common.HttpResponse;
 /**
  * A {@link HttpClient} decorator which maps a {@link Throwable} to a {@link HttpResponse}.
  */
+@Deprecated(forRemoval = true)
 public final class ExceptionMappingClient extends SimpleDecoratingHttpClient {
 
     /**
      * Returns a new {@link HttpClient} decorator which maps a {@link Throwable} to a {@link HttpResponse}
      * using the default {@link ExceptionMappingFunction}.
      */
+    @Deprecated(forRemoval = true)
     public static Function<? super HttpClient, ExceptionMappingClient> newDecorator() {
         return newDecorator(ExceptionMappingFunction.ofDefault());
     }
@@ -52,6 +54,7 @@ public final class ExceptionMappingClient extends SimpleDecoratingHttpClient {
      * Returns a new {@link HttpClient} decorator which maps a {@link Throwable} to a {@link HttpResponse}
      * using the given {@link ExceptionMappingFunction}.
      */
+    @Deprecated(forRemoval = true)
     public static Function<? super HttpClient, ExceptionMappingClient> newDecorator(
             ExceptionMappingFunction mappingFunction) {
         requireNonNull(mappingFunction, "mappingFunction");

--- a/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingFunction.java
+++ b/exception-mapping/src/main/java/dev/gihwan/tollgate/exception/mapping/ExceptionMappingFunction.java
@@ -32,11 +32,13 @@ import com.linecorp.armeria.common.HttpResponse;
  * A {@link Function} for mapping a {@link Throwable} to a {@link HttpResponse}.
  */
 @FunctionalInterface
+@Deprecated(forRemoval = true)
 public interface ExceptionMappingFunction extends Function<Throwable, HttpResponse> {
 
     /**
      * Returns the default implementation of {@link ExceptionMappingFunction}.
      */
+    @Deprecated(forRemoval = true)
     static ExceptionMappingFunction ofDefault() {
         return DefaultExceptionMappingFunction.INSTANCE;
     }


### PR DESCRIPTION
Deprecate `exception-mapping` module. Like #145, it would be better to provide exception handling through `Upstream`.